### PR TITLE
refactor: extract bundle types provider

### DIFF
--- a/packages/unplugin-dts/src/core/providers/api-extractor.ts
+++ b/packages/unplugin-dts/src/core/providers/api-extractor.ts
@@ -1,20 +1,31 @@
-import { ensureAbsolute, mergeObjects, resolve, tryGetPackageInfo, tryGetPkgPath } from './utils'
+import { ensureAbsolute, mergeObjects, resolve, tryGetPackageInfo, tryGetPkgPath } from '../utils'
 
 import type { ExtractorLogLevel, IConfigFile } from '@microsoft/api-extractor'
-import type { BundleConfig, ExtractorInvokeOptions } from './types'
+import type { BundleConfig, ExtractorInvokeOptions, ExtractorResult } from '../types'
+import type { BundleTypesProvider, BundleTypesProviderResult } from './types'
 
-export interface BundleDtsOptions {
+export interface ApiExtractorBundleOptions {
   root: string,
   configPath?: string,
   tsconfigPath?: string,
   compilerOptions: Record<string, any>,
   outDir: string,
   entryPath: string,
+  outputPath?: string,
   fileName: string,
   libFolder?: string,
   extractorConfig?: BundleConfig,
   bundledPackages?: string[],
   invokeOptions?: ExtractorInvokeOptions,
+}
+
+export type ApiExtractorProviderOptions = Pick<
+  ApiExtractorBundleOptions,
+  'configPath' | 'extractorConfig' | 'bundledPackages' | 'invokeOptions'
+>
+
+export interface ApiExtractorProviderResult extends BundleTypesProviderResult {
+  meta: ExtractorResult,
 }
 
 let hasExtractor: boolean | undefined
@@ -34,12 +45,13 @@ export async function bundleDtsFiles({
   compilerOptions,
   outDir,
   entryPath,
+  outputPath,
   fileName,
   libFolder,
   extractorConfig = {},
   bundledPackages,
   invokeOptions = {},
-}: BundleDtsOptions) {
+}: ApiExtractorBundleOptions) {
   const { Extractor, ExtractorConfig } = await import('@microsoft/api-extractor')
 
   configPath = configPath ? ensureAbsolute(configPath, root) : ''
@@ -74,7 +86,7 @@ export async function bundleDtsFiles({
     },
     dtsRollup: {
       enabled: true,
-      publicTrimmedFilePath: resolve(outDir, fileName),
+      publicTrimmedFilePath: outputPath ?? resolve(outDir, fileName),
     },
     tsdocMetadata: {
       enabled: false,
@@ -135,5 +147,40 @@ export async function bundleDtsFiles({
     }
 
     throw error
+  }
+}
+
+export function createApiExtractorProvider({
+  configPath,
+  extractorConfig,
+  bundledPackages,
+  invokeOptions,
+}: ApiExtractorProviderOptions): BundleTypesProvider {
+  return {
+    name: 'api-extractor',
+    async bundle(context) {
+      const result = await bundleDtsFiles({
+        root: context.root,
+        configPath,
+        tsconfigPath: context.tsconfigPath,
+        compilerOptions: context.compilerOptions,
+        outDir: context.outDir,
+        entryPath: context.entryPath,
+        outputPath: context.outputPath,
+        fileName: context.fileName,
+        libFolder: context.libFolder,
+        extractorConfig,
+        bundledPackages,
+        invokeOptions,
+      })
+
+      return {
+        succeeded: result.succeeded,
+        warningCount: result.warningCount,
+        errorCount: result.errorCount,
+        outputPath: context.outputPath,
+        meta: result,
+      } satisfies ApiExtractorProviderResult
+    },
   }
 }

--- a/packages/unplugin-dts/src/core/providers/index.ts
+++ b/packages/unplugin-dts/src/core/providers/index.ts
@@ -1,0 +1,8 @@
+export * from './api-extractor'
+export type * from './types'
+
+import type { BundleTypesProvider, BundleTypesProviderLike } from './types'
+
+export function normalizeProvider(provider: BundleTypesProviderLike): BundleTypesProvider {
+  return typeof provider === 'function' ? { bundle: provider } : provider
+}

--- a/packages/unplugin-dts/src/core/providers/types.ts
+++ b/packages/unplugin-dts/src/core/providers/types.ts
@@ -1,0 +1,33 @@
+import type { Logger } from '../types'
+import type { MaybePromise } from '../utils'
+
+export interface BundleTypesProviderContext {
+  root: string,
+  tsconfigPath?: string,
+  compilerOptions: Record<string, any>,
+  outDir: string,
+  entryPath: string,
+  outputPath: string,
+  fileName: string,
+  libFolder?: string,
+  logger: Logger,
+}
+
+export interface BundleTypesProviderResult {
+  succeeded: boolean,
+  warningCount?: number,
+  errorCount?: number,
+  outputPath: string,
+  meta?: unknown,
+}
+
+export type BundleTypesProviderFn = (
+  context: BundleTypesProviderContext
+) => MaybePromise<BundleTypesProviderResult>
+
+export interface BundleTypesProvider {
+  name?: string,
+  bundle: BundleTypesProviderFn,
+}
+
+export type BundleTypesProviderLike = BundleTypesProvider | BundleTypesProviderFn

--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -8,9 +8,9 @@ import { createFilter } from '@rollup/pluginutils'
 import { compare } from 'compare-versions'
 import { green, red, yellow } from 'kolorist'
 import { loadProgramProcessor } from './processor'
+import { createApiExtractorProvider, getHasExtractor, normalizeProvider } from './providers'
 import { JsonResolver, SvelteResolver, VueResolver, parseResolvers } from './resolvers'
 import { hasExportDefault, hasNormalExport, normalizeGlob, transformCode } from './transform'
-import { bundleDtsFiles, getHasExtractor } from './bundle'
 import {
   cleanVueDtsFileName,
   defaultIndex,
@@ -53,6 +53,7 @@ import type {
   AliasOptions,
   CreateRuntimeOptions,
   EmitOptions,
+  ExtractorResult,
   Logger,
   NormalizedOutDir,
 } from './types'
@@ -808,37 +809,43 @@ export class Runtime {
           const compilerOptions = configPath
             ? getTsConfig(configPath, this.host.readFile).compilerOptions
             : rawCompilerOptions
-
-          const rollup = async (path: string) => {
-            const result = await bundleDtsFiles({
-              root,
+          const provider = normalizeProvider(
+            createApiExtractorProvider({
               // api-extractor.json
               configPath: bundleConfigPath,
+              extractorConfig,
+              bundledPackages,
+              invokeOptions,
+            }),
+          )
+
+          const bundleEntry = async (path: string) => {
+            const result = await provider.bundle({
+              root,
               // tsconfig.json
               tsconfigPath: configPath,
               compilerOptions,
               outDir,
               entryPath: path,
+              outputPath: path,
               // fileName 已经包含正确的后缀（.d.ts / .d.cts / .d.mts）
               fileName: basename(path),
               libFolder: getTsLibFolder(),
-              extractorConfig,
-              bundledPackages,
-              invokeOptions,
+              logger,
             })
 
             emittedFiles.delete(path)
             rollupFiles.add(path)
 
             if (typeof afterRollup === 'function') {
-              await unwrapPromise(afterRollup(result))
+              await unwrapPromise(afterRollup(result.meta as ExtractorResult))
             }
           }
 
           if (multiple) {
             await runParallel(cpus().length, entryNames, async name => {
               // 使用正确的后缀生成打包文件路径
-              await rollup(
+              await bundleEntry(
                 cleanPath(
                   resolve(outDir, tsToDtsWithExtension(name, primaryDtsExtension)),
                   emittedFiles,
@@ -847,7 +854,7 @@ export class Runtime {
             })
           } else {
             // typesPath 已经在上面转换为正确的后缀
-            await rollup(typesPath)
+            await bundleEntry(typesPath)
           }
 
           await runParallel(cpus().length, Array.from(emittedFiles.keys()), f => unlink(f))

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -371,5 +371,61 @@ describe('runtime tests', () => {
     const content = emittedFiles.get(normalizePath(mainDtsPath))
 
     expect(content).toContain("export * from './index.js'")
+  })
+
+  it('should bundle nested multiple entries back to their entry declaration paths', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+      }),
+    )
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'), { recursive: true })
+    writeFileSync(resolve(tempDir, 'src', 'button.ts'), 'export const button = "button"\n')
+    writeFileSync(resolve(tempDir, 'src', 'input.ts'), 'export const input = "input"\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      entries: {
+        'components/button': resolve(tempDir, 'src/button.ts'),
+        'fields/input': resolve(tempDir, 'src/input.ts'),
+      },
+    })
+
+    await runtime.transform(resolve(tempDir, 'src/button.ts'), '')
+    await runtime.transform(resolve(tempDir, 'src/input.ts'), '')
+
+    const emittedFiles = await runtime.emitOutput({ bundleTypes: true })
+
+    const buttonDtsPath = normalizePath(resolve(tempDir, 'dist/components/button.d.ts'))
+    const inputDtsPath = normalizePath(resolve(tempDir, 'dist/fields/input.d.ts'))
+
+    const buttonContent = emittedFiles.get(buttonDtsPath) ?? readFileSync(buttonDtsPath, 'utf-8')
+    const inputContent = emittedFiles.get(inputDtsPath) ?? readFileSync(inputDtsPath, 'utf-8')
+
+    expect(buttonContent).toContain('button')
+    expect(inputContent).toContain('input')
+    expect(buttonContent).not.toContain("export * from '../button.js'")
+    expect(inputContent).not.toContain("export * from '../input.js'")
+    expect(existsSync(resolve(tempDir, 'dist/button.d.ts'))).toBe(false)
+    expect(existsSync(resolve(tempDir, 'dist/input.d.ts'))).toBe(false)
   })
 })

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -427,5 +427,5 @@ describe('runtime tests', () => {
     expect(inputContent).not.toContain("export * from '../input.js'")
     expect(existsSync(resolve(tempDir, 'dist/button.d.ts'))).toBe(false)
     expect(existsSync(resolve(tempDir, 'dist/input.d.ts'))).toBe(false)
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## Summary

- Extract API Extractor bundleTypes logic into core/providers.
- Add an internal provider abstraction for future bundleTypes providers.
- Cover nested multi-entry bundle output paths.

## Tests

- pnpm --filter unplugin-dts test
- pnpm exec tsc --noEmit -p packages/unplugin-dts/tsconfig.json
- git diff --cached --check
- push hook ran pnpm -r run test && pnpm run test:e2e