### PR TITLE
fix(unplugin-dts): correct module-resolution precedence in setModuleResolution

### DIFF
--- a/packages/unplugin-dts/src/core/utils.ts
+++ b/packages/unplugin-dts/src/core/utils.ts
@@ -416,7 +416,7 @@ export function setModuleResolution(options: CompilerOptions) {
   const module =
     typeof options.module === 'number'
       ? options.module
-      : (options.target ?? ts.ScriptTarget.ES5 >= 2)
+      : (options.target ?? ts.ScriptTarget.ES5) >= ts.ScriptTarget.ES2015
         ? ts.ModuleKind.ES2015
         : ts.ModuleKind.CommonJS
 

--- a/packages/unplugin-dts/tests/utils.spec.ts
+++ b/packages/unplugin-dts/tests/utils.spec.ts
@@ -2,6 +2,7 @@ import { normalize, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
+import ts from '../src/core/ts-loader.cjs'
 import {
   base64VLQEncode,
   ensureAbsolute,
@@ -18,6 +19,7 @@ import {
   parseTsAliases,
   queryPublicPath,
   resolveConfigDir,
+  setModuleResolution,
   toCapitalCase,
   transformDtsPath,
   transformSourceMappingURL,
@@ -490,5 +492,30 @@ export interface Test {
 export { testFn } from './comment';
 //# sourceMappingURL=index.d.cts.map`,
     )
+  })
+})
+
+describe('setModuleResolution', () => {
+  it('keeps an explicit moduleResolution', () => {
+    const options: ts.CompilerOptions = {
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    }
+    setModuleResolution(options)
+    expect(options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeNext)
+  })
+
+  it('maps an ES5 target to CommonJS module resolution (Node10)', () => {
+    const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES5 }
+    setModuleResolution(options)
+    expect(options.moduleResolution).toBe(ts.ModuleResolutionKind.Node10)
+  })
+
+  it('maps an ES2015+ target to ES2015 module resolution', () => {
+    const options: ts.CompilerOptions = { target: ts.ScriptTarget.ES2020 }
+    setModuleResolution(options)
+    const expected = ts.version.startsWith('5')
+      ? ts.ModuleResolutionKind.Bundler
+      : ts.ModuleResolutionKind.Classic
+    expect(options.moduleResolution).toBe(expected)
   })
 })


### PR DESCRIPTION
## Problem

In `setModuleResolution` (`packages/unplugin-dts/src/core/utils.ts`), the module default was:

```ts
: (options.target ?? ts.ScriptTarget.ES5 >= 2)
```

`>=` binds tighter than `??`, so this parses as `options.target ?? (ts.ScriptTarget.ES5 >= 2)` = `options.target ?? false`; the resolved target is never compared against ES2015. Called in isolation with an explicit low target like `target: ES5`, the helper selects `ModuleKind.ES2015` instead of the intended CommonJS.

## Scope: internal correctness

Thanks to @qmhc for tracing this. `setModuleResolution` has a single call site in `Runtime`, and the `compilerOptions` passed there spread `fixedCompilerOptions` (`target: ESNext`) beforehand, so the plugin never reaches the ES5 branch. This is an internal-correctness fix to the helper, not an observable change in plugin behaviour today. It removes a latent footgun if the helper is reused, or if that call path ever changes.

## Fix

```ts
: (options.target ?? ts.ScriptTarget.ES5) >= ts.ScriptTarget.ES2015
```

so the default is applied before the comparison, using the enum rather than the literal `2`.

Appended three `setModuleResolution` cases to the existing `utils` suite (an explicit `moduleResolution` is preserved, `ES5 → Node10`, `ES2015+ → ES2015`); the ES5 case fails on the old expression and passes on the fix. The 19 existing tests are unchanged.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*
