### PR TITLE
perf(unplugin-dts): optimize watch rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,29 +65,5 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Preserve Vitest worker exit diagnostics
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vitestPool = Get-ChildItem -Path 'node_modules/.pnpm/vitest@4.1.5_*/node_modules/vitest/dist/chunks/cli-api.*.js' | Select-Object -First 1
-          if (-not $vitestPool) {
-            throw 'Unable to locate the Vitest pool implementation'
-          }
-
-          $content = [System.IO.File]::ReadAllText($vitestPool.FullName)
-          $patched = $content.Replace(
-            'emitUnexpectedExit = () => {',
-            'emitUnexpectedExit = (code, signal) => { console.error("[vitest-worker-exit]", { code, signal });'
-          )
-          if ($patched -eq $content) {
-            throw 'Unable to patch the Vitest worker exit handler'
-          }
-
-          [System.IO.File]::WriteAllText(
-            $vitestPool.FullName,
-            $patched,
-            [System.Text.UTF8Encoding]::new($false)
-          )
-
       - name: Test
         run: pnpm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,29 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Preserve Vitest worker exit diagnostics
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vitestPool = Get-ChildItem -Path 'node_modules/.pnpm/vitest@4.1.5_*/node_modules/vitest/dist/chunks/cli-api.*.js' | Select-Object -First 1
+          if (-not $vitestPool) {
+            throw 'Unable to locate the Vitest pool implementation'
+          }
+
+          $content = [System.IO.File]::ReadAllText($vitestPool.FullName)
+          $patched = $content.Replace(
+            'emitUnexpectedExit = () => {',
+            'emitUnexpectedExit = (code, signal) => { console.error("[vitest-worker-exit]", { code, signal });'
+          )
+          if ($patched -eq $content) {
+            throw 'Unable to patch the Vitest worker exit handler'
+          }
+
+          [System.IO.File]::WriteAllText(
+            $vitestPool.FullName,
+            $patched,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+
       - name: Test
         run: pnpm run test

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -192,6 +192,75 @@ await build({
 })
 ```
 
+## Watch Mode
+
+Keep source directories separate from bundler and declaration output directories. This is the
+recommended layout for watch mode because a bundler can observe source-tree additions, deletions,
+and renames without also watching generated files:
+
+```text
+project/
+├── src/
+│   └── index.ts
+├── dist/
+└── types/
+```
+
+Vite, Webpack, and Rspack can discover newly added files that match your TypeScript configuration
+when the recursive source watch does not resolve into generated output. If an output directory is
+the source directory, or a realpath/symlink makes it overlap existing sources, the plugin fails
+closed: exact existing source files remain watched, but an unreferenced file addition may require a
+watcher restart. This prevents generated files from creating a rebuild loop.
+
+When Webpack or Rspack starts from a clean project and creates nested output directories, Watchpack
+may perform one initial compensating rebuild. Generated output is ignored after that bootstrap, so
+steady-state source additions, deletions, and renames do not form an output feedback loop.
+
+After a source is deleted or renamed, the plugin removes declaration paths that it wrote during the
+previous build but that are absent from the current complete output snapshot. Other files in the
+output directory are left unchanged.
+
+Pure Rollup watch cannot safely register a watched source directory that also contains its outputs
+without help from the calling configuration. In that layout, an unreferenced new file may not
+trigger a rebuild. Prefer moving sources into `src/`. If changing the layout is not possible,
+configure all generated output directories as ignored before calling `rollup.watch` and explicitly
+watch the type source directory:
+
+```js
+import { resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'rollup'
+import typescript from '@rollup/plugin-typescript'
+import dts from 'unplugin-dts/rollup'
+
+const projectRoot = resolve(fileURLToPath(import.meta.url), '..')
+const outputDir = resolve(projectRoot, 'dist')
+
+const watchTypeRoot = {
+  name: 'watch-type-root',
+  buildStart() {
+    if (this.meta.watchMode) this.addWatchFile(projectRoot)
+  },
+}
+
+export default defineConfig({
+  input: resolve(projectRoot, 'index.ts'),
+  output: { dir: outputDir, format: 'es' },
+  watch: {
+    chokidar: {
+      ignored: path => path === outputDir || path.startsWith(`${outputDir}${sep}`),
+    },
+  },
+  plugins: [watchTypeRoot, typescript(), dts({ root: projectRoot })],
+})
+```
+
+If declarations use a different directory, or you have multiple outputs, include every generated
+directory in the ignored predicate. Rolldown currently does not discover unreferenced files created
+after watch starts through a directory `addWatchFile`. Import or reference the new file from an
+existing watched module, or restart the watcher after adding, deleting, or renaming such files.
+
 ## Bundling Types
 
 By default, the generated declaration files follow the source structure.

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -192,6 +192,69 @@ await build({
 })
 ```
 
+## Watch 模式
+
+推荐将源码目录与 bundler、声明文件的输出目录分开。这样构建工具可以监听源码树中的新增、
+删除和重命名，又不会同时监听生成文件：
+
+```text
+project/
+├── src/
+│   └── index.ts
+├── dist/
+└── types/
+```
+
+当递归源码监听不会解析到生成输出时，Vite、Webpack 和 Rspack 可以发现符合 TypeScript
+配置的新文件。如果输出目录就是源码目录，或者 realpath/symlink 使它与已有源码重叠，插件会
+采用 fail-close：继续精确监听已有源码，但新增未引用文件后可能需要重启 watcher。这可以避免
+生成文件形成重新构建循环。
+
+当 Webpack 或 Rspack 从干净项目启动并创建嵌套输出目录时，Watchpack 可能执行一次初始补偿
+构建。bootstrap 完成后生成输出会被忽略，因此稳态下的源码新增、删除和重命名不会形成输出
+反馈循环。
+
+源码删除或重命名后，插件会清理上一轮由自身写出、但已不在当前完整输出快照中的声明路径；
+输出目录中的其他文件不会被清理。
+
+纯 Rollup watch 无法在没有调用方配合的情况下安全监听同时包含输出的源码目录。这种布局下，
+新增但未被引用的文件可能不会触发重新构建。优先将源码移入 `src/`。如果暂时不能调整布局，
+请在调用 `rollup.watch` 前忽略所有生成目录，并显式监听类型源码目录：
+
+```js
+import { resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'rollup'
+import typescript from '@rollup/plugin-typescript'
+import dts from 'unplugin-dts/rollup'
+
+const projectRoot = resolve(fileURLToPath(import.meta.url), '..')
+const outputDir = resolve(projectRoot, 'dist')
+
+const watchTypeRoot = {
+  name: 'watch-type-root',
+  buildStart() {
+    if (this.meta.watchMode) this.addWatchFile(projectRoot)
+  },
+}
+
+export default defineConfig({
+  input: resolve(projectRoot, 'index.ts'),
+  output: { dir: outputDir, format: 'es' },
+  watch: {
+    chokidar: {
+      ignored: path => path === outputDir || path.startsWith(`${outputDir}${sep}`),
+    },
+  },
+  plugins: [watchTypeRoot, typescript(), dts({ root: projectRoot })],
+})
+```
+
+如果声明文件使用不同目录，或配置了多个输出目录，需要在 ignored 判断中覆盖每一个生成目录。
+Rolldown 当前无法通过目录 `addWatchFile` 发现 watch 启动后创建的未引用文件。请从已有的受监听
+模块中导入或引用新文件，或者在新增、删除、重命名这类文件后重启 watcher。
+
 ## 打包类型
 
 默认情况下，生成的类型文件会跟随源文件的结构。

--- a/packages/unplugin-dts/package.json
+++ b/packages/unplugin-dts/package.json
@@ -123,6 +123,7 @@
     "@volar/typescript": "^2.4.26",
     "compare-versions": "^6.1.1",
     "debug": "^4.4.0",
+    "glob-to-regexp": "0.4.1",
     "kolorist": "^1.8.0",
     "local-pkg": "^1.1.1",
     "magic-string": "^0.30.17",

--- a/packages/unplugin-dts/src/core/performance.ts
+++ b/packages/unplugin-dts/src/core/performance.ts
@@ -1,0 +1,130 @@
+import { performance } from 'node:perf_hooks'
+
+export type BuildHook = 'buildStart' | 'watchChange' | 'transform' | 'writeBundle'
+
+interface BuildInterval {
+  hook: BuildHook,
+  start: number,
+  end: number,
+}
+
+interface BuildIntervalToken {
+  hook: BuildHook,
+  start: number,
+  generation: number,
+}
+
+export interface BuildTimingSummary {
+  wallMs: number,
+  attributedMs: number,
+  unattributedMs: number,
+  buildStartMs: number,
+  watchChangeMs: number,
+  transformSumMs: number,
+  transformUnionMs: number,
+  transformMaxConcurrency: number,
+  transformOverlapMs: number,
+  writeBundleMs: number,
+}
+
+function measureIntervals(intervals: readonly BuildInterval[]) {
+  if (intervals.length === 0) {
+    return { sum: 0, union: 0, maxConcurrency: 0 }
+  }
+
+  const sum = intervals.reduce((total, interval) => total + interval.end - interval.start, 0)
+  const points = intervals.flatMap(interval => [
+    { time: interval.start, delta: 1 },
+    { time: interval.end, delta: -1 },
+  ])
+
+  points.sort((left, right) => {
+    if (left.time === right.time) return left.delta - right.delta
+    return left.time - right.time
+  })
+
+  let active = 0
+  let maxConcurrency = 0
+  let previous = points[0].time
+  let union = 0
+
+  for (const point of points) {
+    if (active > 0) union += point.time - previous
+    active += point.delta
+    maxConcurrency = Math.max(maxConcurrency, active)
+    previous = point.time
+  }
+
+  return { sum, union, maxConcurrency }
+}
+
+/**
+ * 跟踪一次声明构建周期内的插件 hook 区间。
+ *
+ * 逐次耗时之和只用于解释工作量；用户可感知耗时使用单调时钟墙钟，
+ * 并发 transform 的归因使用区间并集，避免重复计算重叠时间。
+ */
+export class BuildTimeTracker {
+  private readonly now: () => number
+  private generation = 0
+  private cycleStart = 0
+  private intervals: BuildInterval[] = []
+
+  constructor(now: () => number = () => performance.now()) {
+    this.now = now
+    this.reset()
+  }
+
+  reset(start = this.now()) {
+    this.generation++
+    this.cycleStart = start
+    this.intervals = []
+  }
+
+  begin(hook: BuildHook): BuildIntervalToken {
+    return { hook, start: this.now(), generation: this.generation }
+  }
+
+  end(token: BuildIntervalToken) {
+    if (token.generation !== this.generation) return
+
+    const end = this.now()
+    this.intervals.push({ hook: token.hook, start: token.start, end })
+  }
+
+  async track<T>(hook: BuildHook, action: () => Promise<T>): Promise<T> {
+    const interval = this.begin(hook)
+
+    try {
+      return await action()
+    } finally {
+      this.end(interval)
+    }
+  }
+
+  getIntervals(): readonly BuildInterval[] {
+    return [...this.intervals].sort((left, right) => left.start - right.start)
+  }
+
+  summarize(end = this.now()): BuildTimingSummary {
+    const intervals = this.getIntervals()
+    const all = measureIntervals(intervals)
+    const phase = (hook: BuildHook) =>
+      measureIntervals(intervals.filter(interval => interval.hook === hook))
+    const transforms = phase('transform')
+    const wallMs = Math.max(0, end - this.cycleStart)
+
+    return {
+      wallMs,
+      attributedMs: all.union,
+      unattributedMs: Math.max(0, wallMs - all.union),
+      buildStartMs: phase('buildStart').union,
+      watchChangeMs: phase('watchChange').union,
+      transformSumMs: transforms.sum,
+      transformUnionMs: transforms.union,
+      transformMaxConcurrency: transforms.maxConcurrency,
+      transformOverlapMs: transforms.sum - transforms.union,
+      writeBundleMs: phase('writeBundle').union,
+    }
+  }
+}

--- a/packages/unplugin-dts/src/core/processor/index.ts
+++ b/packages/unplugin-dts/src/core/processor/index.ts
@@ -1,5 +1,17 @@
 import type ts from 'typescript'
 
+export interface SourceFileCacheStats {
+  entries: number,
+  hits: number,
+  misses: number,
+  invalidations: number,
+}
+
+export interface VersionedCompilerHost extends ts.CompilerHost {
+  invalidateSourceFile: (fileName: string) => void,
+  getSourceFileCacheStats: () => SourceFileCacheStats,
+}
+
 export interface ProgramProcessor {
   createParsedCommandLine: (
     _ts: typeof ts,
@@ -7,6 +19,7 @@ export interface ProgramProcessor {
     configPath: string
   ) => ts.ParsedCommandLine,
   createProgram: typeof ts.createProgram,
+  createCompilerHost?: (options: ts.CompilerOptions) => VersionedCompilerHost,
 }
 
 export async function loadProgramProcessor(type: 'vue' | 'ts' = 'ts'): Promise<ProgramProcessor> {

--- a/packages/unplugin-dts/src/core/processor/ts.ts
+++ b/packages/unplugin-dts/src/core/processor/ts.ts
@@ -1,6 +1,112 @@
 import { dirname } from 'node:path'
 
 import ts from '../ts-loader.cjs'
+import { ensureAbsolute, normalizePath } from '../utils'
+
+import type { SourceFileCacheStats, VersionedCompilerHost } from './index'
+
+interface SourceFileCacheEntry {
+  version: number,
+  content: string,
+  languageKey: string,
+  scriptKind: ts.ScriptKind,
+  sourceFile: ts.SourceFile,
+}
+
+function getScriptKind(fileName: string) {
+  if (/\.tsx$/i.test(fileName)) return ts.ScriptKind.TSX
+  if (/\.[cm]?jsx?$/i.test(fileName)) return ts.ScriptKind.JS
+  if (/\.json$/i.test(fileName)) return ts.ScriptKind.JSON
+  return ts.ScriptKind.TS
+}
+
+function getLanguageKey(value: ts.ScriptTarget | ts.CreateSourceFileOptions) {
+  if (typeof value === 'number') return `target:${value}`
+
+  // TypeScript may recreate setExternalModuleIndicator between Programs even when
+  // compiler options are unchanged. Its semantics stay fixed for this host lifetime;
+  // compiler-option changes replace the complete host through a fresh rebuild.
+  return [
+    'options',
+    value.languageVersion,
+    value.impliedNodeFormat ?? '',
+    value.jsDocParsingMode ?? '',
+    value.setExternalModuleIndicator ? 'external' : 'default',
+  ].join('|')
+}
+
+/**
+ * 为纯 TypeScript Program 提供单版本 SourceFile 缓存。
+ *
+ * 每个 canonical path 只保留当前版本，避免 watch 期间累积旧 AST；调用方在收到
+ * 文件变更后先失效对应路径，再把旧 Program 交给 TypeScript 进行结构复用。
+ */
+export function createCompilerHost(options: ts.CompilerOptions): VersionedCompilerHost {
+  const host = ts.createCompilerHost(options)
+  const cache = new Map<string, SourceFileCacheEntry>()
+  const versions = new Map<string, number>()
+  const stats: SourceFileCacheStats = { entries: 0, hits: 0, misses: 0, invalidations: 0 }
+  const getCanonicalPath = (fileName: string) => {
+    const absolute = ensureAbsolute(fileName, host.getCurrentDirectory())
+    return normalizePath(host.getCanonicalFileName(absolute))
+  }
+  const getSourceFile = host.getSourceFile.bind(host)
+
+  host.getSourceFile = (fileName, languageVersionOrOptions, onError, shouldCreateNewSourceFile) => {
+    const path = getCanonicalPath(fileName)
+    const version = versions.get(path) ?? 0
+    const languageKey = getLanguageKey(languageVersionOrOptions)
+    const scriptKind = getScriptKind(fileName)
+    const cached = cache.get(path)
+
+    if (
+      !shouldCreateNewSourceFile &&
+      cached?.version === version &&
+      cached.languageKey === languageKey &&
+      cached.scriptKind === scriptKind
+    ) {
+      stats.hits++
+      return cached.sourceFile
+    }
+
+    stats.misses++
+    const sourceFile = getSourceFile(
+      fileName,
+      languageVersionOrOptions,
+      onError,
+      shouldCreateNewSourceFile,
+    )
+
+    if (sourceFile) {
+      cache.set(path, {
+        version,
+        content: sourceFile.text,
+        languageKey,
+        scriptKind,
+        sourceFile,
+      })
+      stats.entries = cache.size
+    } else {
+      cache.delete(path)
+      stats.entries = cache.size
+    }
+
+    return sourceFile
+  }
+
+  return Object.assign(host, {
+    invalidateSourceFile(fileName: string) {
+      const path = getCanonicalPath(fileName)
+      versions.set(path, (versions.get(path) ?? 0) + 1)
+      cache.delete(path)
+      stats.entries = cache.size
+      stats.invalidations++
+    },
+    getSourceFileCacheStats() {
+      return { ...stats }
+    },
+  })
+}
 
 export function createParsedCommandLine(
   _ts: typeof ts,

--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -47,7 +47,7 @@ import {
 } from './utils'
 
 import type { Alias } from './types'
-import type { ProgramProcessor } from './processor'
+import type { ProgramProcessor, SourceFileCacheStats, VersionedCompilerHost } from './processor'
 import type { Resolver } from './resolvers'
 import type {
   AliasOptions,
@@ -69,6 +69,89 @@ const fixedCompilerOptions: ts.CompilerOptions = {
   preserveSymlinks: false,
   noEmitOnError: undefined,
   target: ts.ScriptTarget.ESNext,
+}
+
+export interface ProgramChange {
+  fileName?: string,
+  event?: 'create' | 'update' | 'delete',
+  forceFresh?: boolean,
+}
+
+export interface RuntimeWatchTargets {
+  files: string[],
+  directories: string[],
+  contextDirectories: string[],
+  outputDirectories: string[],
+}
+
+export function isCanonicalPathEqualOrInside(
+  canonicalFileName: string,
+  canonicalDirectory: string,
+) {
+  const directoryPrefix = canonicalDirectory.endsWith('/')
+    ? canonicalDirectory
+    : `${canonicalDirectory}/`
+  return canonicalFileName === canonicalDirectory || canonicalFileName.startsWith(directoryPrefix)
+}
+
+interface ProgramReuseStats {
+  mode: 'fresh' | 'incremental',
+  reason: string,
+  sourceFiles: number,
+  reusedSourceFiles: number,
+  nonDefaultSourceFiles: number,
+  reusedNonDefaultSourceFiles: number,
+  cacheHits: number,
+  cacheMisses: number,
+  cacheInvalidations: number,
+  cacheEntries: number,
+}
+
+function isVersionedCompilerHost(host: ts.CompilerHost): host is VersionedCompilerHost {
+  const candidate = host as Partial<VersionedCompilerHost>
+  return (
+    typeof candidate.invalidateSourceFile === 'function' &&
+    typeof candidate.getSourceFileCacheStats === 'function'
+  )
+}
+
+function getDiagnostics(program: ts.Program) {
+  return [
+    ...program.getDeclarationDiagnostics(),
+    ...program.getSemanticDiagnostics(),
+    ...program.getSyntacticDiagnostics(),
+  ]
+}
+
+interface RuntimeInternals {
+  runtimeOptions: CreateRuntimeOptions,
+  programProcessor: ProgramProcessor,
+  projectReferences: readonly ts.ProjectReference[] | undefined,
+  configWatchDirectories: string[],
+  emittedFilePaths: Set<string>,
+  cleanStaleOutputs: boolean,
+  lastProgramReuse: ProgramReuseStats,
+  rebuildProgramIncremental: (changes: readonly ProgramChange[]) => string[],
+  isConfigFile: (fileName: string) => boolean,
+  shouldHandleWatchChange: (fileName: string) => boolean,
+  getWatchTargets: () => RuntimeWatchTargets,
+  filterWatchDirectories: (
+    directories: readonly string[],
+    outputDirectories: readonly string[]
+  ) => string[],
+  isWatchDirectory: (fileName: string) => boolean,
+}
+
+const runtimeInternals = new WeakMap<Runtime, RuntimeInternals>()
+
+function getRuntimeInternals(runtime: Runtime) {
+  const internals = runtimeInternals.get(runtime)
+  if (!internals) throw new Error('Runtime is not initialized')
+  return internals
+}
+
+function shouldMeasureProgramReuse() {
+  return handleDebug.enabled
 }
 
 function isEmptyDeclarationEntry(content: string | undefined) {
@@ -144,19 +227,20 @@ export class Runtime {
   protected libName: string
   protected indexName: string
   protected logger: Logger
-
   protected resolvers: Resolver[]
   protected rootFiles: Set<string>
   protected outputFiles: Map<string, string>
   protected transformedFiles: Set<string>
 
+  private programSourceFilesByCanonicalName: Map<string, ts.SourceFile> | undefined
+  private watchDirectoryNames: Set<string> | undefined
+  private watchTargets: RuntimeWatchTargets | undefined
+
   readonly filter: (id: string) => boolean
   readonly rebuildProgram: () => void
 
-  protected constructor(
-    options: CreateRuntimeOptions,
-    { createParsedCommandLine, createProgram }: ProgramProcessor,
-  ) {
+  protected constructor(options: CreateRuntimeOptions, programProcessor: ProgramProcessor) {
+    const { createCompilerHost, createParsedCommandLine, createProgram } = programProcessor
     const {
       root,
       tsconfigPath,
@@ -274,15 +358,16 @@ export class Runtime {
       ),
     ]
 
-    const host = ts.createCompilerHost(compilerOptions)
-    const rebuildProgram = () =>
-      createProgram({
-        host,
-        rootNames,
-        options: compilerOptions,
-        projectReferences: content?.projectReferences,
-      })
-    const program = rebuildProgram()
+    const host =
+      createCompilerHost && process.env.DTS_DISABLE_SOURCE_FILE_CACHE !== '1'
+        ? createCompilerHost(compilerOptions)
+        : ts.createCompilerHost(compilerOptions)
+    const program = createProgram({
+      host,
+      rootNames,
+      options: compilerOptions,
+      projectReferences: content?.projectReferences,
+    })
 
     const libName = toCapitalCase(options.libName || '_default')
     const indexName = options.indexName || defaultIndex
@@ -321,11 +406,7 @@ export class Runtime {
       options.entryRoot || (useTs6ImplicitRootDir ? sourcePublicPath || publicRoot : publicRoot)
     entryRoot = ensureAbsolute(entryRoot, root)
 
-    const diagnostics = [
-      ...program.getDeclarationDiagnostics(),
-      ...program.getSemanticDiagnostics(),
-      ...program.getSyntacticDiagnostics(),
-    ]
+    const diagnostics = getDiagnostics(program)
 
     if (diagnostics?.length) {
       logger.error(ts.formatDiagnosticsWithColorAndContext(diagnostics, host))
@@ -362,9 +443,252 @@ export class Runtime {
     this.filter = filter
 
     this.program = program
-    this.rebuildProgram = () => {
-      this.program = rebuildProgram()
+    const cacheStats = this.getSourceFileCacheStats()
+    const measureInitialReuse = shouldMeasureProgramReuse()
+    const lastProgramReuse: ProgramReuseStats = {
+      mode: 'fresh',
+      reason: 'initial',
+      sourceFiles: measureInitialReuse ? program.getSourceFiles().length : 0,
+      reusedSourceFiles: 0,
+      nonDefaultSourceFiles: measureInitialReuse
+        ? program
+          .getSourceFiles()
+          .filter(sourceFile => !program.isSourceFileDefaultLibrary(sourceFile)).length
+        : 0,
+      reusedNonDefaultSourceFiles: 0,
+      cacheHits: cacheStats.hits,
+      cacheMisses: cacheStats.misses,
+      cacheInvalidations: cacheStats.invalidations,
+      cacheEntries: cacheStats.entries,
     }
+    this.rebuildProgram = () => {
+      const internals = getRuntimeInternals(this)
+      const { createCompilerHost, createProgram } = internals.programProcessor
+
+      if (createCompilerHost) {
+        this.host =
+          process.env.DTS_DISABLE_SOURCE_FILE_CACHE === '1'
+            ? ts.createCompilerHost(this.compilerOptions)
+            : createCompilerHost(this.compilerOptions)
+      }
+
+      this.program = createProgram({
+        host: this.host,
+        rootNames: this.rootNames,
+        options: this.compilerOptions,
+        projectReferences: internals.projectReferences,
+      })
+      this.programSourceFilesByCanonicalName = undefined
+      this.watchDirectoryNames = undefined
+      this.watchTargets = undefined
+    }
+    runtimeInternals.set(this, {
+      runtimeOptions: options,
+      programProcessor,
+      projectReferences: content?.projectReferences,
+      configWatchDirectories: Object.keys(content?.wildcardDirectories ?? {}).map(normalizePath),
+      emittedFilePaths: new Set(),
+      cleanStaleOutputs: false,
+      lastProgramReuse,
+      rebuildProgramIncremental: changes => this.rebuildProgramIncremental(changes),
+      isConfigFile: fileName => this.isConfigFile(fileName),
+      shouldHandleWatchChange: fileName => this.shouldHandleWatchChange(fileName),
+      getWatchTargets: () => this.getWatchTargets(),
+      filterWatchDirectories: (directories, outputDirectories) =>
+        this.filterWatchDirectories(directories, outputDirectories),
+      isWatchDirectory: fileName => this.isWatchDirectory(fileName),
+    })
+  }
+
+  private getSourceFileCacheStats(): SourceFileCacheStats {
+    return isVersionedCompilerHost(this.host)
+      ? this.host.getSourceFileCacheStats()
+      : { entries: 0, hits: 0, misses: 0, invalidations: 0 }
+  }
+
+  private getCanonicalFileName(fileName: string) {
+    return normalizePath(
+      this.host.getCanonicalFileName(ensureAbsolute(fileName, this.host.getCurrentDirectory())),
+    )
+  }
+
+  private measureProgramReuse(
+    previousProgram: ts.Program,
+    mode: ProgramReuseStats['mode'],
+    reason: string,
+    previousCacheStats: SourceFileCacheStats,
+  ) {
+    const currentCacheStats = this.getSourceFileCacheStats()
+    const cacheStats = {
+      cacheHits: currentCacheStats.hits - previousCacheStats.hits,
+      cacheMisses: currentCacheStats.misses - previousCacheStats.misses,
+      cacheInvalidations: currentCacheStats.invalidations - previousCacheStats.invalidations,
+      cacheEntries: currentCacheStats.entries,
+    }
+
+    if (!shouldMeasureProgramReuse()) {
+      getRuntimeInternals(this).lastProgramReuse = {
+        mode,
+        reason,
+        sourceFiles: 0,
+        reusedSourceFiles: 0,
+        nonDefaultSourceFiles: 0,
+        reusedNonDefaultSourceFiles: 0,
+        ...cacheStats,
+      }
+      return
+    }
+
+    const previousSourceFiles = new Map(
+      previousProgram
+        .getSourceFiles()
+        .map(sourceFile => [this.getCanonicalFileName(sourceFile.fileName), sourceFile] as const),
+    )
+    const sourceFiles = this.program.getSourceFiles()
+    const reusedSourceFiles = sourceFiles.filter(
+      sourceFile =>
+        previousSourceFiles.get(this.getCanonicalFileName(sourceFile.fileName)) === sourceFile,
+    )
+    const nonDefaultSourceFiles = sourceFiles.filter(
+      sourceFile => !this.program.isSourceFileDefaultLibrary(sourceFile),
+    )
+    const reused = new Set(reusedSourceFiles)
+
+    getRuntimeInternals(this).lastProgramReuse = {
+      mode,
+      reason,
+      sourceFiles: sourceFiles.length,
+      reusedSourceFiles: reusedSourceFiles.length,
+      nonDefaultSourceFiles: nonDefaultSourceFiles.length,
+      reusedNonDefaultSourceFiles: nonDefaultSourceFiles.filter(sourceFile =>
+        reused.has(sourceFile),
+      ).length,
+      ...cacheStats,
+    }
+    handleDebug('program rebuild %O', getRuntimeInternals(this).lastProgramReuse)
+  }
+
+  private refreshDiagnostics() {
+    this.diagnostics = getDiagnostics(this.program)
+
+    if (this.diagnostics.length) {
+      this.logger.error(ts.formatDiagnosticsWithColorAndContext(this.diagnostics, this.host))
+    }
+  }
+
+  private rebuildFresh(previousProgram: ts.Program, reason: string) {
+    const internals = getRuntimeInternals(this)
+    if (
+      reason === 'create' ||
+      reason === 'delete' ||
+      reason === 'config' ||
+      reason === 'forced' ||
+      reason === 'untracked-file' ||
+      reason === 'missing-file'
+    ) {
+      internals.cleanStaleOutputs = true
+    }
+    const rebuildProgram = this.rebuildProgram
+    const fresh = new Runtime(internals.runtimeOptions, internals.programProcessor)
+    const freshInternals = getRuntimeInternals(fresh)
+    Object.assign(this, fresh)
+    Object.defineProperty(this, 'rebuildProgram', {
+      value: rebuildProgram,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+    internals.projectReferences = freshInternals.projectReferences
+    internals.configWatchDirectories = freshInternals.configWatchDirectories
+    this.measureProgramReuse(previousProgram, 'fresh', reason, {
+      entries: 0,
+      hits: 0,
+      misses: 0,
+      invalidations: 0,
+    })
+  }
+
+  private rebuildProgramWithCurrentHost(previousProgram: ts.Program, reason: string) {
+    const internals = getRuntimeInternals(this)
+    this.program = internals.programProcessor.createProgram({
+      host: this.host,
+      rootNames: this.rootNames,
+      options: this.compilerOptions,
+      projectReferences: internals.projectReferences,
+    })
+    this.programSourceFilesByCanonicalName = undefined
+    this.watchDirectoryNames = undefined
+    this.watchTargets = undefined
+    this.refreshDiagnostics()
+    this.measureProgramReuse(previousProgram, 'fresh', reason, {
+      entries: 0,
+      hits: 0,
+      misses: 0,
+      invalidations: 0,
+    })
+  }
+
+  private rebuildProgramIncremental(changes: readonly ProgramChange[]) {
+    const previousProgram = this.program
+    const host = this.host
+    const programSourceFiles = new Map<string, ts.SourceFile>()
+    let fallbackReason = ''
+
+    for (const change of changes) {
+      const fileName = change.fileName && normalizePath(change.fileName)
+      const event = change.event ?? 'update'
+      const programSourceFile = fileName ? this.getProgramSourceFile(fileName) : undefined
+
+      if (change.forceFresh) fallbackReason = 'forced'
+      else if (!fileName) fallbackReason = 'missing-file'
+      else if (event !== 'update') fallbackReason = event
+      else if (this.isConfigFile(fileName)) fallbackReason = 'config'
+      else if (this.matchResolver(fileName) || fileName.endsWith('.json')) {
+        fallbackReason = 'resolver'
+      } else if (!programSourceFile) fallbackReason = 'untracked-file'
+      else {
+        programSourceFiles.set(
+          this.getCanonicalFileName(programSourceFile.fileName),
+          programSourceFile,
+        )
+      }
+
+      if (fallbackReason) break
+    }
+
+    if (!isVersionedCompilerHost(host)) {
+      const reason = fallbackReason || 'cache-disabled'
+      if (!fallbackReason || fallbackReason === 'resolver') {
+        this.rebuildProgramWithCurrentHost(previousProgram, reason)
+      } else {
+        this.rebuildFresh(previousProgram, reason)
+      }
+      return this.getChangedProgramSourceFiles(changes)
+    }
+
+    if (fallbackReason) {
+      this.rebuildFresh(previousProgram, fallbackReason)
+      return this.getChangedProgramSourceFiles(changes)
+    }
+
+    const previousCacheStats = this.getSourceFileCacheStats()
+    for (const sourceFile of programSourceFiles.values()) {
+      host.invalidateSourceFile(sourceFile.fileName)
+    }
+    const internals = getRuntimeInternals(this)
+    this.program = internals.programProcessor.createProgram({
+      host,
+      rootNames: this.rootNames,
+      options: this.compilerOptions,
+      projectReferences: internals.projectReferences,
+      oldProgram: previousProgram,
+    })
+    this.programSourceFilesByCanonicalName = undefined
+    this.watchDirectoryNames = undefined
+    this.watchTargets = undefined
+    this.refreshDiagnostics()
+    this.measureProgramReuse(previousProgram, 'incremental', 'source-update', previousCacheStats)
+    return this.getChangedProgramSourceFiles(changes)
   }
 
   getHost() {
@@ -373,6 +697,115 @@ export class Runtime {
 
   getProgram() {
     return this.program
+  }
+
+  private getProgramSourceFile(fileName: string) {
+    if (!this.programSourceFilesByCanonicalName) {
+      this.programSourceFilesByCanonicalName = new Map(
+        this.program
+          .getSourceFiles()
+          .map(sourceFile => [this.getCanonicalFileName(sourceFile.fileName), sourceFile]),
+      )
+    }
+
+    return this.programSourceFilesByCanonicalName.get(this.getCanonicalFileName(fileName))
+  }
+
+  private getChangedProgramSourceFiles(changes: readonly ProgramChange[]) {
+    const sourceFiles = new Set<string>()
+    for (const change of changes) {
+      if (!change.fileName) continue
+      const sourceFile = this.getProgramSourceFile(change.fileName)
+      if (sourceFile) sourceFiles.add(normalizePath(sourceFile.fileName))
+    }
+    return [...sourceFiles]
+  }
+
+  private isConfigFile(fileName: string) {
+    return (
+      !!this.configPath &&
+      this.getCanonicalFileName(fileName) === this.getCanonicalFileName(this.configPath)
+    )
+  }
+
+  private shouldHandleWatchChange(fileName: string) {
+    return (
+      this.filter(fileName) ||
+      this.isConfigFile(fileName) ||
+      !!this.matchResolver(fileName) ||
+      !!this.getProgramSourceFile(fileName)
+    )
+  }
+
+  private getWatchTargets(): RuntimeWatchTargets {
+    if (this.watchTargets) return this.watchTargets
+
+    const files = new Set(this.getRootFiles())
+    const directories = new Set<string>()
+    const contextDirectories = new Set<string>()
+    for (const directory of getRuntimeInternals(this).configWatchDirectories) {
+      directories.add(directory)
+    }
+    if (this.configPath) files.add(normalizePath(this.configPath))
+
+    for (const sourceFile of this.program.getSourceFiles()) {
+      if (!this.program.isSourceFileDefaultLibrary(sourceFile)) {
+        files.add(normalizePath(sourceFile.fileName))
+
+        if (!this.program.isSourceFileFromExternalLibrary(sourceFile)) {
+          directories.add(normalizePath(dirname(sourceFile.fileName)))
+        }
+      }
+    }
+
+    for (const directory of directories) {
+      const isInsideOutDir = this.outDirs.some(outDir =>
+        this.isPathEqualOrInside(directory, outDir.dir),
+      )
+      const containsOutDir = this.outDirs.some(outDir =>
+        this.isPathEqualOrInside(outDir.dir, directory),
+      )
+
+      if (!isInsideOutDir) files.add(directory)
+      if (!isInsideOutDir && !containsOutDir) contextDirectories.add(directory)
+    }
+
+    this.watchTargets = {
+      files: [...files].filter(file => !directories.has(file)),
+      directories: [...files].filter(file => directories.has(file)),
+      contextDirectories: [...contextDirectories],
+      outputDirectories: this.outDirs.map(outDir => outDir.dir),
+    }
+    return this.watchTargets
+  }
+
+  private isPathEqualOrInside(fileName: string, directory: string) {
+    const canonicalFileName = this.getCanonicalFileName(fileName)
+    const canonicalDirectory = this.getCanonicalFileName(directory)
+    return isCanonicalPathEqualOrInside(canonicalFileName, canonicalDirectory)
+  }
+
+  private filterWatchDirectories(
+    directories: readonly string[],
+    outputDirectories: readonly string[],
+  ) {
+    return directories.filter(directory =>
+      outputDirectories.every(
+        outputDirectory =>
+          !this.isPathEqualOrInside(directory, outputDirectory) &&
+          !this.isPathEqualOrInside(outputDirectory, directory),
+      ),
+    )
+  }
+
+  private isWatchDirectory(fileName: string) {
+    if (!this.watchDirectoryNames) {
+      this.watchDirectoryNames = new Set(
+        this.getWatchTargets().directories.map(directory => this.getCanonicalFileName(directory)),
+      )
+    }
+
+    return this.watchDirectoryNames.has(this.getCanonicalFileName(fileName))
   }
 
   matchResolver(id: string) {
@@ -541,6 +974,7 @@ export class Runtime {
     const outDir = outDirs[0].dir
     const primaryOutDirConfig = outDirs[0]
     const emittedFiles = new Map<string, string>()
+    const currentEmittedFilePaths = new Set<string>()
     const declareModules: string[] = []
 
     const writeOutput = async (
@@ -586,6 +1020,7 @@ export class Runtime {
       await mkdir(dir, { recursive: true })
 
       await writeFile(path, content, 'utf-8')
+      currentEmittedFilePaths.add(path)
       record && emittedFiles.set(path, content)
     }
 
@@ -899,6 +1334,7 @@ export class Runtime {
           )
 
           await runParallel(maxConcurrency, unbundledFiles, f => unlink(f))
+          for (const file of unbundledFiles) currentEmittedFilePaths.delete(file)
           removeDirIfEmpty(outDir)
           emittedFiles.clear()
 
@@ -970,8 +1406,66 @@ export class Runtime {
       })
     }
 
+    const internals = getRuntimeInternals(this)
+    if (internals.cleanStaleOutputs) {
+      const staleFiles = [...internals.emittedFilePaths].filter(
+        fileName => !currentEmittedFilePaths.has(fileName),
+      )
+      await runParallel(maxConcurrency, staleFiles, async fileName => {
+        try {
+          await unlink(fileName)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        }
+      })
+      internals.emittedFilePaths = currentEmittedFilePaths
+      internals.cleanStaleOutputs = false
+    } else {
+      for (const fileName of currentEmittedFilePaths) {
+        internals.emittedFilePaths.add(fileName)
+      }
+    }
+
     this.clearTransformedFiles()
 
     return emittedFiles
   }
+}
+
+export function rebuildRuntimeProgram(
+  runtime: Runtime,
+  changes: ProgramChange | readonly ProgramChange[],
+) {
+  return getRuntimeInternals(runtime).rebuildProgramIncremental(
+    Array.isArray(changes) ? changes : [changes],
+  )
+}
+
+export function isRuntimeConfigFile(runtime: Runtime, fileName: string) {
+  return getRuntimeInternals(runtime).isConfigFile(fileName)
+}
+
+export function shouldHandleRuntimeWatchChange(runtime: Runtime, fileName: string) {
+  return getRuntimeInternals(runtime).shouldHandleWatchChange(fileName)
+}
+
+export function getRuntimeWatchTargets(
+  runtime: Runtime,
+  bundlerOutputDirectories: readonly string[] = [],
+) {
+  const internals = getRuntimeInternals(runtime)
+  const targets = internals.getWatchTargets()
+  return {
+    files: [...targets.files],
+    directories: [...targets.directories],
+    contextDirectories: internals.filterWatchDirectories(
+      targets.contextDirectories,
+      bundlerOutputDirectories,
+    ),
+    outputDirectories: [...targets.outputDirectories],
+  }
+}
+
+export function isRuntimeWatchDirectory(runtime: Runtime, fileName: string) {
+  return getRuntimeInternals(runtime).isWatchDirectory(fileName)
 }

--- a/packages/unplugin-dts/src/glob-to-regexp.d.ts
+++ b/packages/unplugin-dts/src/glob-to-regexp.d.ts
@@ -1,0 +1,9 @@
+declare module 'glob-to-regexp' {
+  interface GlobToRegExpOptions {
+    extended?: boolean,
+    flags?: string,
+    globstar?: boolean,
+  }
+
+  export default function globToRegExp(glob: string, options?: GlobToRegExpOptions): RegExp
+}

--- a/packages/unplugin-dts/src/plugin.ts
+++ b/packages/unplugin-dts/src/plugin.ts
@@ -1,10 +1,11 @@
-import { basename, dirname } from 'node:path'
+import { basename, dirname, isAbsolute, relative } from 'node:path'
 import { readdirSync } from 'node:fs'
 
 import ts from './core/ts-loader.cjs'
+import globToRegExp from 'glob-to-regexp'
 import { cyan, green, yellow } from 'kolorist'
+import { BuildTimeTracker } from './core/performance'
 import {
-  Runtime,
   defaultIndex,
   dtsRE,
   ensureAbsolute,
@@ -18,20 +19,72 @@ import {
   tjsRE,
   unwrapPromise,
 } from './core'
+import {
+  Runtime,
+  getRuntimeWatchTargets,
+  isCanonicalPathEqualOrInside,
+  isRuntimeConfigFile,
+  isRuntimeWatchDirectory,
+  rebuildRuntimeProgram,
+  shouldHandleRuntimeWatchChange,
+} from './core/runtime'
 
 import type {
   RolldownPlugin,
   RollupPlugin,
   RspackCompiler,
+  UnpluginBuildContext,
   UnpluginFactory,
   WebpackCompiler,
 } from 'unplugin'
 import type { Alias } from './core'
 import type { PluginOptions } from './types'
 import type { Logger } from './core'
+import type { ProgramChange } from './core/runtime'
 
 const pluginName = 'unplugin:dts'
 const logPrefix = cyan(`[${pluginName}]`)
+
+type NativeWatchFileSystem = NonNullable<WebpackCompiler['watchFileSystem']>
+type NativeWatchParameters = Parameters<NativeWatchFileSystem['watch']>
+type NativeWatchIgnored = NativeWatchParameters[4]['ignored'] | ((fileName: string) => boolean)
+type NativeWatchOptions = Omit<NativeWatchParameters[4], 'ignored'> & {
+  ignored?: NativeWatchIgnored,
+}
+
+function nativeWatchGlobToSource(ignored: string) {
+  if (!ignored.length) return undefined
+  const source = globToRegExp(ignored, { globstar: true, extended: true }).source
+  return source.slice(0, -1) + '(?:$|\\/)'
+}
+
+function nativeWatchIgnoredToPredicate(ignored: NativeWatchIgnored) {
+  if (Array.isArray(ignored)) {
+    const sources = ignored.map(nativeWatchGlobToSource).filter(Boolean) as string[]
+    if (!sources.length) return () => false
+    const regexp = new RegExp(sources.join('|'))
+    return (fileName: string) => regexp.test(normalizePath(fileName))
+  }
+  if (typeof ignored === 'string') {
+    const source = nativeWatchGlobToSource(ignored)
+    if (!source) return () => false
+    const regexp = new RegExp(source)
+    return (fileName: string) => regexp.test(normalizePath(fileName))
+  }
+  if (ignored instanceof RegExp) {
+    return (fileName: string) => ignored.test(normalizePath(fileName))
+  }
+  if (typeof ignored === 'function') return ignored
+  return () => false
+}
+
+export function mergeNativeWatchIgnored(
+  ignored: NativeWatchIgnored,
+  isAdditionalIgnored: (fileName: string) => boolean,
+): NativeWatchIgnored {
+  const isIgnored = nativeWatchIgnoredToPredicate(ignored)
+  return (fileName: string) => isIgnored(fileName) || isAdditionalIgnored(fileName)
+}
 
 export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = /* #__PURE__ */ (
   options = {},
@@ -74,11 +127,211 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
 
   let isDev = false
   let bundled = false
-  let timeRecord = 0
+  const buildTime = new BuildTimeTracker()
+  let bundlerOutDirs: string[] = []
+  let nativeWatchIgnoredDirectories: string[] = []
+  const preparedWatchFileSystems = new WeakSet<object>()
 
   let entryPromise: Promise<any> | undefined
 
   let runtime: Runtime
+  const pendingProgramChanges = new Map<string, ProgramChange>()
+
+  function queueProgramChange(change: ProgramChange) {
+    const fileName = change.fileName && normalizePath(change.fileName)
+    const key = fileName
+      ? ts.sys.useCaseSensitiveFileNames
+        ? fileName
+        : fileName.toLowerCase()
+      : '__missing__'
+    const previous = pendingProgramChanges.get(key)
+    pendingProgramChanges.set(key, {
+      fileName,
+      event: change.event ?? previous?.event,
+      forceFresh: change.forceFresh || previous?.forceFresh,
+    })
+  }
+
+  function isInsideWatchIgnoredDirectory(fileName: string) {
+    fileName = ensureAbsolute(fileName, root)
+    const canonicalFileName = ts.sys.useCaseSensitiveFileNames
+      ? normalizePath(fileName)
+      : normalizePath(fileName).toLowerCase()
+
+    return nativeWatchIgnoredDirectories.some(directory => {
+      const canonicalDirectory = ts.sys.useCaseSensitiveFileNames
+        ? normalizePath(directory)
+        : normalizePath(directory).toLowerCase()
+      return (
+        canonicalFileName === canonicalDirectory ||
+        canonicalFileName.startsWith(`${canonicalDirectory}/`)
+      )
+    })
+  }
+
+  function isPathEqualOrInside(fileName: string, directory: string) {
+    const canonicalFileName = ts.sys.useCaseSensitiveFileNames
+      ? normalizePath(fileName)
+      : normalizePath(fileName).toLowerCase()
+    const canonicalDirectory = ts.sys.useCaseSensitiveFileNames
+      ? normalizePath(directory)
+      : normalizePath(directory).toLowerCase()
+    return isCanonicalPathEqualOrInside(canonicalFileName, canonicalDirectory)
+  }
+
+  function getRealPath(fileName: string) {
+    const unresolvedSegments: string[] = []
+    let existingPath = normalizePath(fileName)
+
+    while (!ts.sys.fileExists(existingPath) && !ts.sys.directoryExists(existingPath)) {
+      const parent = normalizePath(dirname(existingPath))
+      if (parent === existingPath) return undefined
+      unresolvedSegments.unshift(basename(existingPath))
+      existingPath = parent
+    }
+
+    try {
+      const realExistingPath = ts.sys.realpath?.(existingPath)
+      if (!realExistingPath) return undefined
+      return unresolvedSegments.length
+        ? resolve(realExistingPath, ...unresolvedSegments)
+        : realExistingPath
+    } catch {
+      return undefined
+    }
+  }
+
+  function getWatchPathAliases(directory: string) {
+    const normalizedDirectory = normalizePath(directory)
+    const aliases = new Set([normalizedDirectory])
+    const realDirectory = getRealPath(normalizedDirectory)
+    if (realDirectory) aliases.add(normalizePath(realDirectory))
+
+    if (isPathEqualOrInside(normalizedDirectory, root)) {
+      const realRoot = getRealPath(root)
+      if (realRoot) {
+        const relativeDirectory = normalizePath(relative(root, normalizedDirectory))
+        if (!isAbsolute(relativeDirectory) && !relativeDirectory.startsWith('../')) {
+          aliases.add(normalizePath(resolve(realRoot, relativeDirectory)))
+        }
+      }
+    }
+
+    return [...aliases]
+  }
+
+  function isAnyPathEqualOrInside(fileNames: readonly string[], directories: readonly string[]) {
+    return fileNames.some(fileName =>
+      directories.some(directory => isPathEqualOrInside(fileName, directory)),
+    )
+  }
+
+  function isInsideNativeWatchIgnoredDirectory(fileName: string) {
+    return nativeWatchIgnoredDirectories.some(directory => isPathEqualOrInside(fileName, directory))
+  }
+
+  function prepareNativeWatchFileSystem(compiler: WebpackCompiler | RspackCompiler) {
+    compiler.hooks.afterEnvironment.tap(pluginName, () => {
+      const watchFileSystem = compiler.watchFileSystem as NativeWatchFileSystem | null
+      if (!watchFileSystem || preparedWatchFileSystems.has(watchFileSystem)) return
+
+      preparedWatchFileSystems.add(watchFileSystem)
+      const watch = watchFileSystem.watch.bind(watchFileSystem)
+      watchFileSystem.watch = (...parameters: NativeWatchParameters) => {
+        const watchOptions = parameters[4] as NativeWatchOptions
+        parameters[4] = {
+          ...watchOptions,
+          ignored: nativeWatchIgnoredDirectories.length
+            ? mergeNativeWatchIgnored(watchOptions.ignored, isInsideNativeWatchIgnoredDirectory)
+            : watchOptions.ignored,
+        } as NativeWatchParameters[4]
+        return watch(...parameters)
+      }
+    })
+  }
+
+  function captureRollupOutputDirectories(options: unknown) {
+    const outputs = ensureArray(
+      (
+        options as {
+          output?: { dir?: string, file?: string } | { dir?: string, file?: string }[],
+        }
+      ).output,
+    ).filter((output): output is { dir?: string, file?: string } => !!output)
+    bundlerOutDirs = outputs.flatMap(output => {
+      if (output.dir) return [ensureAbsolute(output.dir, process.cwd())]
+      if (output.file) return [ensureAbsolute(dirname(output.file), process.cwd())]
+      return []
+    })
+  }
+
+  function addRuntimeWatchTargets(context: UnpluginBuildContext) {
+    if (meta.framework === 'esbuild') return
+
+    const targets = getRuntimeWatchTargets(runtime, bundlerOutDirs)
+    const outputDirectories = [
+      ...new Set([...targets.outputDirectories, ...bundlerOutDirs].map(normalizePath)),
+    ]
+    const fileAliases = targets.files.map(getWatchPathAliases)
+    const outputTargets = outputDirectories.map(directory => {
+      const aliases = getWatchPathAliases(directory)
+      return {
+        directory,
+        aliases,
+        canIgnore: fileAliases.every(
+          sourceAliases => !isAnyPathEqualOrInside(sourceAliases, aliases),
+        ),
+      }
+    })
+    const ignoredOutputDirectories = outputTargets.filter(target => target.canIgnore)
+    nativeWatchIgnoredDirectories = [
+      ...new Set(ignoredOutputDirectories.flatMap(target => target.aliases)),
+    ]
+    for (const file of targets.files) {
+      context.addWatchFile(file)
+    }
+
+    function canWatchDirectory(directory: string, canIgnoreNestedOutputs: boolean) {
+      const directoryAliases = getWatchPathAliases(directory)
+      return outputTargets.every(outputTarget => {
+        if (isAnyPathEqualOrInside(directoryAliases, outputTarget.aliases)) return false
+        if (!isAnyPathEqualOrInside(outputTarget.aliases, directoryAliases)) return true
+        return canIgnoreNestedOutputs && outputTarget.canIgnore
+      })
+    }
+
+    const nativeContext = context.getNativeBuildContext?.()
+    if (nativeContext?.framework === 'webpack' || nativeContext?.framework === 'rspack') {
+      const compilation = nativeContext.compilation
+      if (compilation) {
+        const contextDirectories = targets.directories.filter(directory =>
+          canWatchDirectory(directory, true),
+        )
+        for (const directory of contextDirectories) {
+          compilation.contextDependencies.add(directory)
+        }
+      }
+      return
+    }
+
+    const directories =
+      meta.framework === 'rollup' || meta.framework === 'rolldown'
+        ? targets.contextDirectories.filter(directory => canWatchDirectory(directory, false))
+        : targets.directories.filter(directory => canWatchDirectory(directory, true))
+    for (const directory of directories) {
+      context.addWatchFile(directory)
+    }
+  }
+
+  function flushPendingProgramChanges() {
+    if (!pendingProgramChanges.size) return
+
+    const changedSourceFiles = rebuildRuntimeProgram(runtime, [...pendingProgramChanges.values()])
+    for (const sourceFile of changedSourceFiles) {
+      runtime.addRootFile(sourceFile)
+    }
+    pendingProgramChanges.clear()
+  }
 
   function hasVueFilesInDir(dir: string): boolean {
     try {
@@ -160,12 +413,16 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
     if (!options.outDirs && compiler.options.output.path) {
       outDirs = [ensureAbsolute(compiler.options.output.path, root)]
     }
+    bundlerOutDirs = compiler.options.output.path
+      ? [ensureAbsolute(compiler.options.output.path, root)]
+      : []
 
     handleDebug('parse webpack(rspack) config')
   }
 
   const rollupHooks: Partial<RollupPlugin> = {
     options(options) {
+      captureRollupOutputDirectories(options)
       const input = typeof options.input === 'string' ? [options.input] : options.input
 
       if (Array.isArray(input)) {
@@ -201,11 +458,22 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
     name: 'unplugin-dts',
     enforce: 'pre',
     async buildStart() {
-      if (isDev || runtime) return
+      if (isDev) return
+
+      if (runtime) {
+        const interval = buildTime.begin('buildStart')
+        try {
+          flushPendingProgramChanges()
+          addRuntimeWatchTargets(this)
+        } finally {
+          buildTime.end(interval)
+        }
+        return
+      }
 
       handleDebug('begin buildStart')
-      timeRecord = 0
-      const startTime = Date.now()
+      buildTime.reset()
+      const interval = buildTime.begin('buildStart')
 
       if (entryPromise) {
         await entryPromise
@@ -303,18 +571,14 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
         )
       }
 
-      if (meta.framework !== 'esbuild') {
-        for (const file of runtime.getRootFiles()) {
-          this.addWatchFile(file)
-        }
-      }
+      addRuntimeWatchTargets(this)
 
       if (typeof afterBootstrap === 'function') {
         await unwrapPromise(afterBootstrap(runtime))
       }
 
       handleDebug('create ts program')
-      timeRecord += Date.now() - startTime
+      buildTime.end(interval)
     },
     async transform(code, id) {
       id = normalizePath(id).split('?')[0]
@@ -323,45 +587,48 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
 
       if (!runtime.matchResolver(id) && !tjsRE.test(id)) return
 
-      const startTime = Date.now()
-
-      await runtime.transform(id, code)
-
-      timeRecord += Date.now() - startTime
+      await buildTime.track('transform', () => runtime.transform(id, code))
     },
-    watchChange(id) {
-      id = normalizePath(id)
+    watchChange(id, change) {
+      id = normalizePath(id).split('?')[0]
 
-      if (isDev || !runtime || !runtime.filter(id)) {
+      const isWatchDirectory = runtime && isRuntimeWatchDirectory(runtime, id)
+      if (
+        isDev ||
+        !runtime ||
+        (!isWatchDirectory && !shouldHandleRuntimeWatchChange(runtime, id))
+      ) {
         return
       }
 
-      id = id.split('?')[0]
+      if (bundled) buildTime.reset()
+      const interval = buildTime.begin('watchChange')
 
-      if (!runtime.matchResolver(id) && !tjsRE.test(id)) {
+      if (
+        !isWatchDirectory &&
+        !isRuntimeConfigFile(runtime, id) &&
+        !runtime.matchResolver(id) &&
+        !tjsRE.test(id)
+      ) {
         // Non-type files (e.g. CSS) changed: no need to rebuild program,
         // but need to restore rootFiles and allow writeBundle to re-emit
         // declarations. This is important in watch mode because the bundler
         // may empty outDir during rebuild, deleting previously emitted .d.ts.
         runtime.restoreRootFiles()
         bundled = false
-        timeRecord = 0
+        buildTime.end(interval)
         return
       }
 
-      const sourceFile = runtime.getHost().getSourceFile(id, ts.ScriptTarget.ESNext)
+      runtime.restoreRootFiles()
+      bundled = false
+      queueProgramChange({
+        fileName: id,
+        event: change?.event,
+        forceFresh: isWatchDirectory,
+      })
 
-      if (sourceFile) {
-        runtime.restoreRootFiles()
-        runtime.addRootFile(normalizePath(sourceFile.fileName))
-
-        bundled = false
-        timeRecord = 0
-        // We lose the fast way to trigger source file re-emit in Volar 1,
-        // so now we have to rebuild the program to get the latest declaration
-        // files of those changed files.
-        runtime.rebuildProgram()
-      }
+      buildTime.end(interval)
     },
     async writeBundle() {
       if (isDev || !runtime || bundled) {
@@ -374,7 +641,7 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
       handleDebug('begin writeBundle')
       logger.info(green(`\n${logPrefix} Start generate declaration files...`))
 
-      const startTime = Date.now()
+      const interval = buildTime.begin('writeBundle')
 
       if (typeof afterDiagnostic === 'function') {
         await unwrapPromise(afterDiagnostic(runtime.getDiagnostics()))
@@ -398,14 +665,32 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
       }
 
       handleDebug('finish')
+      buildTime.end(interval)
+      const timing = buildTime.summarize()
+      handleDebug('timing summary %O', timing)
       logger.info(
-        green(`${logPrefix} Declaration files built in ${timeRecord + Date.now() - startTime}ms.\n`),
+        green(`${logPrefix} Declaration files built in ${Math.round(timing.attributedMs)}ms.\n`),
       )
     },
     vite: {
       apply: 'build',
       config(config) {
         const aliasOptions = config?.resolve?.alias ?? []
+
+        const watchOptions = config.build?.watch
+        if (watchOptions) {
+          const chokidarOptions = watchOptions.chokidar ?? {}
+          config.build!.watch = {
+            ...watchOptions,
+            chokidar: {
+              ...chokidarOptions,
+              ignored: [
+                ...ensureArray(chokidarOptions.ignored),
+                (fileName: string) => isInsideWatchIgnoredDirectory(fileName),
+              ],
+            },
+          }
+        }
 
         if (isNativeObj(aliasOptions)) {
           aliases = Object.entries(aliasOptions).map(([key, value]) => {
@@ -419,6 +704,7 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
       async configResolved(config) {
         logger = config.logger
         root = ensureAbsolute(options.root ?? '', config.root)
+        bundlerOutDirs = [ensureAbsolute(config.build.outDir, root)]
 
         if (config.build.lib) {
           const input =
@@ -481,6 +767,7 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
     },
     webpack(compiler) {
       prepareFromCompiler(compiler)
+      prepareNativeWatchFileSystem(compiler)
 
       compiler.hooks.emit.tap('UnpluginDtsRemoveAssets', compilation => {
         if (declarationOnly) {
@@ -490,6 +777,7 @@ export const pluginFactory: UnpluginFactory<PluginOptions | undefined, false> = 
     },
     rspack(compiler) {
       prepareFromCompiler(compiler)
+      prepareNativeWatchFileSystem(compiler)
 
       compiler.hooks.thisCompilation.tap('UnpluginDtsRemoveAssets', compilation => {
         compilation.hooks.processAssets.tap(

--- a/packages/unplugin-dts/tests/performance.spec.ts
+++ b/packages/unplugin-dts/tests/performance.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { BuildTimeTracker } from '../src/core/performance'
+
+describe('build time tracker', () => {
+  it('does not double-count concurrently pending transform promises', async () => {
+    let now = 0
+    const tracker = new BuildTimeTracker(() => now)
+    tracker.reset(0)
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+
+    const first = tracker.track(
+      'transform',
+      () => new Promise<void>(fulfill => (resolveFirst = fulfill)),
+    )
+    now = 5
+    const second = tracker.track(
+      'transform',
+      () => new Promise<void>(fulfill => (resolveSecond = fulfill)),
+    )
+    now = 10
+    resolveFirst()
+    await first
+    now = 15
+    resolveSecond()
+    await second
+
+    const timing = tracker.summarize(15)
+
+    expect(timing.transformSumMs).toBe(20)
+    expect(timing.transformUnionMs).toBe(15)
+    expect(timing.transformOverlapMs).toBe(5)
+    expect(timing.transformMaxConcurrency).toBe(2)
+    expect(timing.attributedMs).toBe(15)
+    expect(timing.attributedMs).toBeLessThanOrEqual(timing.wallMs)
+  })
+
+  it('keeps watchChange before the next build and reports unattributed gaps', () => {
+    let now = 0
+    const tracker = new BuildTimeTracker(() => now)
+    tracker.reset(0)
+
+    now = 1
+    const watchChange = tracker.begin('watchChange')
+    now = 6
+    tracker.end(watchChange)
+    now = 10
+    const buildStart = tracker.begin('buildStart')
+    now = 12
+    tracker.end(buildStart)
+    const writeBundle = tracker.begin('writeBundle')
+    now = 20
+    tracker.end(writeBundle)
+
+    expect(tracker.getIntervals().map(interval => interval.hook)).toEqual([
+      'watchChange',
+      'buildStart',
+      'writeBundle',
+    ])
+    expect(tracker.summarize(20)).toMatchObject({
+      wallMs: 20,
+      watchChangeMs: 5,
+      buildStartMs: 2,
+      writeBundleMs: 8,
+      attributedMs: 15,
+      unattributedMs: 5,
+    })
+  })
+})

--- a/packages/unplugin-dts/tests/plugin-performance.spec.ts
+++ b/packages/unplugin-dts/tests/plugin-performance.spec.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { pluginFactory } from '../src/plugin'
+
+import type { BuildTimeTracker as ActualBuildTimeTracker } from '../src/core/performance'
+
+const timingMock = vi.hoisted(() => ({ trackers: [] as ActualBuildTimeTracker[] }))
+
+vi.mock('../src/core/performance', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/core/performance')>()
+
+  return {
+    ...actual,
+    BuildTimeTracker: class extends actual.BuildTimeTracker {
+      constructor() {
+        super()
+        timingMock.trackers.push(this)
+      }
+    },
+  }
+})
+
+describe('plugin performance lifecycle', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    timingMock.trackers.length = 0
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('keeps consecutive watchChange intervals before the next writeBundle', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-performance-'))
+    mkdirSync(resolve(tempDir, 'src'))
+    const sourcePath = resolve(tempDir, 'src/index.ts')
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: {}, include: ['src/**/*'] }),
+    )
+    writeFileSync(sourcePath, "export const value = 'before'\n")
+
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        outDirs: resolve(tempDir, 'dist'),
+        tsconfigPath: 'tsconfig.json',
+      },
+      { framework: 'vite' },
+    )
+
+    await (plugin as any).buildStart.call({ addWatchFile: () => {} })
+    await (plugin as any).writeBundle()
+    writeFileSync(sourcePath, "export const value = 'after'\n")
+    ;(plugin as any).watchChange.call({ addWatchFile: () => {} }, sourcePath, { event: 'update' })
+    writeFileSync(sourcePath, "export const value = 'again'\n")
+    ;(plugin as any).watchChange.call({ addWatchFile: () => {} }, sourcePath, { event: 'update' })
+
+    const tracker = timingMock.trackers.at(-1)!
+    expect(tracker.getIntervals().map(interval => interval.hook)).toEqual([
+      'watchChange',
+      'watchChange',
+    ])
+
+    await (plugin as any).buildStart.call({ addWatchFile: () => {} })
+    await (plugin as any).writeBundle()
+
+    expect(tracker.getIntervals().map(interval => interval.hook)).toEqual([
+      'watchChange',
+      'watchChange',
+      'buildStart',
+      'writeBundle',
+    ])
+    expect(tracker.summarize().watchChangeMs).toBeGreaterThan(0)
+  })
+})

--- a/packages/unplugin-dts/tests/plugin.spec.ts
+++ b/packages/unplugin-dts/tests/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve as pathResolve, relative } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -67,5 +67,229 @@ describe('plugin tests', () => {
 
     expect(runtime.outputFiles.has(dtsPath)).toBe(true)
     expect(runtime.outputFiles.get(dtsPath)).toBe('export declare const parser: any;\n')
+  })
+
+  it('should rebuild the queued Program before transforms in buildStart', async () => {
+    tempDir = mkdtempSync(pathResolve(tmpdir(), 'unplugin-dts-'))
+    const sourcePath = pathResolve(tempDir, 'index.ts')
+
+    writeFileSync(
+      pathResolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: {}, include: ['index.ts'] }),
+    )
+    writeFileSync(sourcePath, "export const value = 'before'\n")
+
+    let runtime: any
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        tsconfigPath: 'tsconfig.json',
+        afterBootstrap: (instance: any) => {
+          runtime = instance
+        },
+      },
+      { framework: 'vite' },
+    )
+
+    await (plugin as any).buildStart.call({ addWatchFile: () => {} })
+    const previousProgram = runtime.getProgram()
+    writeFileSync(sourcePath, "export const value = 'after'\n")
+
+    expect(
+      (plugin as any).watchChange.call({ addWatchFile: () => {} }, sourcePath, { event: 'update' }),
+    ).toBeUndefined()
+    expect(runtime.getProgram()).toBe(previousProgram)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath)).text).toContain("'before'")
+
+    await (plugin as any).buildStart.call({ addWatchFile: () => {} })
+    expect(runtime.getProgram()).not.toBe(previousProgram)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath)).text).toContain("'after'")
+  })
+
+  it('should keep the bootstrapped Runtime identity across fresh config rebuilds', async () => {
+    tempDir = mkdtempSync(pathResolve(tmpdir(), 'unplugin-dts-'))
+    const configPath = pathResolve(tempDir, 'tsconfig.json')
+    const sourcePath = pathResolve(tempDir, 'index.ts')
+    const otherPath = pathResolve(tempDir, 'other.ts')
+    writeFileSync(configPath, JSON.stringify({ include: ['index.ts'] }))
+    writeFileSync(sourcePath, 'export const value = true\n')
+    writeFileSync(otherPath, 'export const other = true\n')
+
+    let runtime: any
+    let bootstrapCalls = 0
+    const watched = new Set<string>()
+    const context = { addWatchFile: (file: string) => watched.add(normalizePath(file)) }
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        tsconfigPath: 'tsconfig.json',
+        afterBootstrap: (instance: any) => {
+          runtime = instance
+          bootstrapCalls++
+        },
+      },
+      { framework: 'vite' },
+    )
+
+    await (plugin as any).buildStart.call(context)
+    const initialRuntime = runtime
+    const initialProgram = runtime.getProgram()
+    expect(watched).toContain(normalizePath(configPath))
+    expect(watched).toContain(normalizePath(tempDir))
+
+    writeFileSync(configPath, JSON.stringify({ include: ['other.ts'] }))
+    ;(plugin as any).watchChange.call(context, configPath, { event: 'update' })
+    expect(runtime.getProgram()).toBe(initialProgram)
+    await (plugin as any).buildStart.call(context)
+
+    expect(runtime).toBe(initialRuntime)
+    expect(runtime.getProgram()).not.toBe(initialProgram)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))).toBeUndefined()
+    expect(runtime.getProgram().getSourceFile(normalizePath(otherPath))).toBeDefined()
+    expect(bootstrapCalls).toBe(1)
+  })
+
+  it('should pass refreshed diagnostics to afterDiagnostic on each watch build', async () => {
+    tempDir = mkdtempSync(pathResolve(tmpdir(), 'unplugin-dts-'))
+    const sourcePath = pathResolve(tempDir, 'index.ts')
+    writeFileSync(
+      pathResolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true }, include: ['index.ts'] }),
+    )
+    writeFileSync(sourcePath, "export const value: string = 'valid'\n")
+
+    const diagnosticCodes: number[][] = []
+    const context = { addWatchFile: () => {} }
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        outDirs: pathResolve(tempDir, 'types'),
+        tsconfigPath: 'tsconfig.json',
+        afterDiagnostic: diagnostics => {
+          diagnosticCodes.push(diagnostics.map(diagnostic => diagnostic.code))
+        },
+      },
+      { framework: 'vite' },
+    )
+
+    await (plugin as any).buildStart.call(context)
+    await (plugin as any).writeBundle()
+
+    writeFileSync(sourcePath, 'export const value: string = 1\n')
+    ;(plugin as any).watchChange.call(context, sourcePath, { event: 'update' })
+    await (plugin as any).buildStart.call(context)
+    await (plugin as any).writeBundle()
+
+    writeFileSync(sourcePath, "export const value: string = 'fixed'\n")
+    ;(plugin as any).watchChange.call(context, sourcePath, { event: 'update' })
+    await (plugin as any).buildStart.call(context)
+    await (plugin as any).writeBundle()
+
+    expect(diagnosticCodes).toHaveLength(3)
+    expect(diagnosticCodes[0]).not.toContain(2322)
+    expect(diagnosticCodes[1]).toContain(2322)
+    expect(diagnosticCodes[2]).not.toContain(2322)
+  })
+
+  it('should batch a consistent multi-file update without transient diagnostics', async () => {
+    tempDir = mkdtempSync(pathResolve(tmpdir(), 'unplugin-dts-'))
+    const firstPath = pathResolve(tempDir, 'a.ts')
+    const secondPath = pathResolve(tempDir, 'b.ts')
+    writeFileSync(
+      pathResolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true }, include: ['*.ts'] }),
+    )
+    writeFileSync(firstPath, "import { b } from './b'\nexport const a: string = b\n")
+    writeFileSync(secondPath, "export const b = 'before'\n")
+
+    const errors: string[] = []
+    const diagnosticCodes: number[][] = []
+    let runtime: any
+    const context = { addWatchFile: () => {} }
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        outDirs: pathResolve(tempDir, 'types'),
+        tsconfigPath: 'tsconfig.json',
+        afterBootstrap(instance: any) {
+          runtime = instance
+          instance.logger = {
+            info() {},
+            warn() {},
+            error(message: unknown) {
+              errors.push(String(message))
+            },
+          }
+        },
+        afterDiagnostic: diagnostics => {
+          diagnosticCodes.push(diagnostics.map(diagnostic => diagnostic.code))
+        },
+      },
+      { framework: 'vite' },
+    )
+
+    await (plugin as any).buildStart.call(context)
+    await (plugin as any).writeBundle()
+    const previousProgram = runtime.getProgram()
+    writeFileSync(firstPath, "import { b } from './b'\nexport const a: number = b\n")
+    writeFileSync(secondPath, 'export const b = 1\n')
+    ;(plugin as any).watchChange.call(context, firstPath, { event: 'update' })
+    ;(plugin as any).watchChange.call(context, secondPath, { event: 'update' })
+
+    expect(runtime.getProgram()).toBe(previousProgram)
+    expect(errors).toEqual([])
+    await (plugin as any).buildStart.call(context)
+    expect(runtime.getProgram()).not.toBe(previousProgram)
+    expect(runtime.getDiagnostics()).toEqual([])
+    expect(errors).toEqual([])
+    await (plugin as any).writeBundle()
+    expect(diagnosticCodes).toEqual([[], []])
+  })
+
+  it('should register Webpack source directories as context dependencies', async () => {
+    tempDir = mkdtempSync(pathResolve(tmpdir(), 'unplugin-dts-'))
+    const sourceDirectory = pathResolve(tempDir, 'src')
+    const sourcePath = pathResolve(sourceDirectory, 'index.ts')
+    const addedPath = pathResolve(sourceDirectory, 'new.ts')
+    mkdirSync(sourceDirectory)
+    writeFileSync(pathResolve(tempDir, 'tsconfig.json'), JSON.stringify({ include: ['src/*.ts'] }))
+    writeFileSync(sourcePath, 'export const value = true\n')
+
+    let runtime: any
+    const fileDependencies = new Set<string>()
+    const contextDependencies = new Set<string>()
+    const context = {
+      addWatchFile: (file: string) => fileDependencies.add(normalizePath(file)),
+      getNativeBuildContext: () => ({
+        framework: 'webpack',
+        compilation: { contextDependencies },
+      }),
+    }
+    const plugin = pluginFactory(
+      {
+        processor: 'ts',
+        root: tempDir,
+        outDirs: pathResolve(tempDir, 'types'),
+        tsconfigPath: 'tsconfig.json',
+        afterBootstrap(instance: any) {
+          runtime = instance
+        },
+      },
+      { framework: 'webpack', webpack: { compiler: {} as any } },
+    )
+
+    await (plugin as any).buildStart.call(context)
+    expect(fileDependencies).toContain(normalizePath(sourcePath))
+    expect(fileDependencies).not.toContain(normalizePath(sourceDirectory))
+    expect(contextDependencies).toContain(normalizePath(sourceDirectory))
+
+    writeFileSync(addedPath, 'export const added = true\n')
+    ;(plugin as any).watchChange.call(context, sourceDirectory, { event: 'update' })
+    await (plugin as any).buildStart.call(context)
+    expect(runtime.getProgram().getSourceFile(normalizePath(addedPath))).toBeDefined()
   })
 })

--- a/packages/unplugin-dts/tests/processor-ts.spec.ts
+++ b/packages/unplugin-dts/tests/processor-ts.spec.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createCompilerHost } from '../src/core/processor/ts'
+import ts from '../src/core/ts-loader.cjs'
+
+describe('TypeScript processor host', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('keeps one SourceFile per version and parse key', () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-ts-host-'))
+    const sourcePath = resolve(tempDir, 'index.ts')
+    writeFileSync(sourcePath, "export const value = 'before'\n")
+
+    const host = createCompilerHost({ target: ts.ScriptTarget.ESNext })
+    const first = host.getSourceFile(sourcePath, ts.ScriptTarget.ESNext)!
+    const reused = host.getSourceFile(sourcePath, ts.ScriptTarget.ESNext)!
+    const optionsFirst = host.getSourceFile(sourcePath, {
+      languageVersion: ts.ScriptTarget.ESNext,
+      setExternalModuleIndicator() {},
+    })!
+    const optionsReused = host.getSourceFile(sourcePath, {
+      languageVersion: ts.ScriptTarget.ESNext,
+      setExternalModuleIndicator() {},
+    })!
+    const differentTarget = host.getSourceFile(sourcePath, ts.ScriptTarget.ES2020)!
+    const forced = host.getSourceFile(sourcePath, ts.ScriptTarget.ES2020, undefined, true)!
+
+    expect(reused).toBe(first)
+    expect(optionsFirst).not.toBe(first)
+    expect(optionsReused).toBe(optionsFirst)
+    expect(differentTarget).not.toBe(first)
+    expect(forced).not.toBe(differentTarget)
+    expect(host.getSourceFileCacheStats().entries).toBe(1)
+
+    writeFileSync(sourcePath, "export const value = 'after'\n")
+    host.invalidateSourceFile(sourcePath)
+    const changed = host.getSourceFile(sourcePath, ts.ScriptTarget.ESNext)!
+
+    expect(changed).not.toBe(differentTarget)
+    expect(changed.text).toContain("'after'")
+
+    for (let version = 0; version < 3; version++) {
+      writeFileSync(sourcePath, `export const value = ${version}\n`)
+      host.invalidateSourceFile(sourcePath)
+      host.getSourceFile(sourcePath, ts.ScriptTarget.ESNext)
+      expect(host.getSourceFileCacheStats().entries).toBe(1)
+    }
+
+    expect(host.getSourceFileCacheStats().entries).toBe(1)
+  })
+})

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -1,18 +1,42 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { Runtime } from '../src/core/runtime'
+import {
+  Runtime,
+  getRuntimeWatchTargets,
+  isCanonicalPathEqualOrInside,
+  rebuildRuntimeProgram,
+} from '../src/core/runtime'
 import { normalizePath } from '../src/core/utils'
+
+function emitDeclarations(program: ReturnType<Runtime['getProgram']>) {
+  const declarations = new Map<string, string>()
+  program.emit(
+    undefined,
+    (fileName, content) => declarations.set(normalizePath(fileName), content),
+    undefined,
+    true,
+  )
+  return [...declarations].sort(([left], [right]) => left.localeCompare(right))
+}
 
 describe('runtime tests', () => {
   let tempDir: string
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true })
     }
+  })
+
+  it('should compare descendants of filesystem roots without duplicating separators', () => {
+    expect(isCanonicalPathEqualOrInside('/project/src', '/')).toBe(true)
+    expect(isCanonicalPathEqualOrInside('C:/project/src', 'C:/')).toBe(true)
+    expect(isCanonicalPathEqualOrInside('//server/share/project/src', '//server/share/')).toBe(true)
+    expect(isCanonicalPathEqualOrInside('/other/src', '/project')).toBe(false)
   })
 
   it('should resolve paths relative to tsconfig dir when baseUrl is absent', async () => {
@@ -154,6 +178,364 @@ describe('runtime tests', () => {
     })
 
     expect((runtime as any).aliasesExclude).toEqual(aliasesExclude)
+  })
+
+  it('should reuse unchanged SourceFile identities for leaf and dependency updates', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    mkdirSync(resolve(tempDir, 'src'))
+    const indexPath = resolve(tempDir, 'src/index.ts')
+    const commonPath = resolve(tempDir, 'src/common.ts')
+    const leafPath = resolve(tempDir, 'src/leaf.ts')
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true }, include: ['src/**/*'] }),
+    )
+    writeFileSync(indexPath, "export { common } from './common'\nexport { leaf } from './leaf'\n")
+    writeFileSync(commonPath, "export const common = 'before'\n")
+    writeFileSync(leafPath, "export const leaf = 'before'\n")
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    expect(getRuntimeWatchTargets(runtime).directories).toContain(
+      normalizePath(resolve(tempDir, 'src')),
+    )
+    const initialProgram = runtime.getProgram()
+    const initialIndex = initialProgram.getSourceFile(normalizePath(indexPath))!
+    const initialCommon = initialProgram.getSourceFile(normalizePath(commonPath))!
+    const initialLeaf = initialProgram.getSourceFile(normalizePath(leafPath))!
+
+    writeFileSync(leafPath, "export const leaf = 'after'\n")
+    rebuildRuntimeProgram(runtime, { fileName: leafPath, event: 'update' })
+
+    const leafProgram = runtime.getProgram()
+    expect(leafProgram.getSourceFile(normalizePath(indexPath))).toBe(initialIndex)
+    expect(leafProgram.getSourceFile(normalizePath(commonPath))).toBe(initialCommon)
+    expect(leafProgram.getSourceFile(normalizePath(leafPath))).not.toBe(initialLeaf)
+
+    const leafAfterFirstUpdate = leafProgram.getSourceFile(normalizePath(leafPath))!
+    const declarationsBeforeCommonUpdate = emitDeclarations(leafProgram)
+    writeFileSync(commonPath, "export const common = 'after'\n")
+    rebuildRuntimeProgram(runtime, { fileName: commonPath, event: 'update' })
+
+    expect(runtime.getProgram().getSourceFile(normalizePath(commonPath))).not.toBe(initialCommon)
+    expect(runtime.getProgram().getSourceFile(normalizePath(leafPath))).toBe(leafAfterFirstUpdate)
+
+    const incrementalDeclarations = emitDeclarations(runtime.getProgram())
+    const freshRuntime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    const freshDeclarations = emitDeclarations(freshRuntime.getProgram())
+    expect(incrementalDeclarations).toEqual(freshDeclarations)
+    expect(incrementalDeclarations).not.toEqual(declarationsBeforeCommonUpdate)
+  })
+
+  it('should distinguish exact and recursive watches around output overlaps', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    const sourceDirectory = resolve(tempDir, 'src')
+    const sourcePath = resolve(sourceDirectory, 'index.ts')
+    mkdirSync(sourceDirectory)
+    writeFileSync(resolve(tempDir, 'tsconfig.json'), JSON.stringify({ files: ['src/index.ts'] }))
+    writeFileSync(sourcePath, 'export const value = true\n')
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      outDirs: resolve(tempDir, 'types'),
+      tsconfigPath: 'tsconfig.json',
+    })
+
+    const watchTargets = getRuntimeWatchTargets(runtime)
+    expect(watchTargets.files).toContain(normalizePath(sourcePath))
+    expect(watchTargets.directories).toContain(normalizePath(sourceDirectory))
+    expect(watchTargets.contextDirectories).toContain(normalizePath(sourceDirectory))
+    const overlappingRuntime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      outDirs: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    const overlappingTargets = getRuntimeWatchTargets(overlappingRuntime)
+    expect(overlappingTargets.directories).not.toContain(normalizePath(sourceDirectory))
+    expect(overlappingTargets.contextDirectories).not.toContain(normalizePath(sourceDirectory))
+
+    const rootSourcePath = resolve(tempDir, 'index.ts')
+    writeFileSync(resolve(tempDir, 'tsconfig.json'), JSON.stringify({ include: ['*.ts'] }))
+    writeFileSync(rootSourcePath, 'export const rootValue = true\n')
+
+    const ancestorRuntime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      outDirs: resolve(tempDir, 'dist'),
+      tsconfigPath: 'tsconfig.json',
+    })
+    const ancestorTargets = getRuntimeWatchTargets(ancestorRuntime)
+
+    expect(ancestorTargets.files).toContain(normalizePath(rootSourcePath))
+    expect(ancestorTargets.directories).toContain(normalizePath(tempDir))
+    expect(ancestorTargets.contextDirectories).not.toContain(normalizePath(tempDir))
+  })
+
+  it('should refresh complete diagnostics after incremental rebuilds', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    const sourcePath = resolve(tempDir, 'index.ts')
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true }, include: ['index.ts'] }),
+    )
+    writeFileSync(sourcePath, "export const value: string = 'valid'\n")
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      logger: { info() {}, warn() {}, error() {} },
+    })
+    const freshDiagnosticCodes = async () => {
+      const freshRuntime = await Runtime.toInstance({
+        processor: 'ts',
+        root: tempDir,
+        tsconfigPath: 'tsconfig.json',
+        logger: { info() {}, warn() {}, error() {} },
+      })
+      return freshRuntime
+        .getDiagnostics()
+        .map(diagnostic => diagnostic.code)
+        .sort((left, right) => left - right)
+    }
+
+    writeFileSync(sourcePath, 'export const value: string = 1\n')
+    rebuildRuntimeProgram(runtime, { fileName: sourcePath, event: 'update' })
+    let diagnosticCodes = runtime
+      .getDiagnostics()
+      .map(diagnostic => diagnostic.code)
+      .sort((left, right) => left - right)
+    expect(diagnosticCodes).toEqual(await freshDiagnosticCodes())
+    expect(diagnosticCodes).toContain(2322)
+
+    writeFileSync(sourcePath, "export const value: string = 'fixed'\n")
+    rebuildRuntimeProgram(runtime, { fileName: sourcePath, event: 'update' })
+    diagnosticCodes = runtime
+      .getDiagnostics()
+      .map(diagnostic => diagnostic.code)
+      .sort((left, right) => left - right)
+    expect(diagnosticCodes).toEqual(await freshDiagnosticCodes())
+    expect(diagnosticCodes).not.toContain(2322)
+  })
+
+  it('should use fresh fallback for root-set and tsconfig changes', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    mkdirSync(resolve(tempDir, 'src'))
+    mkdirSync(resolve(tempDir, 'extra'))
+    const configPath = resolve(tempDir, 'tsconfig.json')
+    const initialPath = resolve(tempDir, 'src/index.ts')
+    const addedPath = resolve(tempDir, 'src/added.ts')
+    const extraPath = resolve(tempDir, 'extra/extra.ts')
+
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        compilerOptions: { paths: { '@/*': ['./src/*'] } },
+        include: ['src/**/*'],
+      }),
+    )
+    writeFileSync(initialPath, 'export const initial = true\n')
+    writeFileSync(extraPath, 'export const extra = true\n')
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      pathsToAliases: true,
+    })
+    let previousHost = runtime.getHost()
+    let previousInitialSource = runtime.getProgram().getSourceFile(normalizePath(initialPath))!
+
+    writeFileSync(addedPath, 'export const added = true\n')
+    rebuildRuntimeProgram(runtime, { fileName: addedPath, event: 'create' })
+    expect(runtime.getHost()).not.toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(initialPath))).not.toBe(
+      previousInitialSource,
+    )
+    expect(runtime.getProgram().getSourceFile(normalizePath(addedPath))).toBeDefined()
+
+    previousHost = runtime.getHost()
+    previousInitialSource = runtime.getProgram().getSourceFile(normalizePath(initialPath))!
+    rmSync(addedPath)
+    rebuildRuntimeProgram(runtime, { fileName: addedPath, event: 'delete' })
+    expect(runtime.getHost()).not.toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(initialPath))).not.toBe(
+      previousInitialSource,
+    )
+    expect(runtime.getProgram().getSourceFile(normalizePath(addedPath))).toBeUndefined()
+
+    previousHost = runtime.getHost()
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        compilerOptions: { baseUrl: '.', paths: { '#/*': ['./extra/*'] } },
+        files: ['extra/extra.ts'],
+        exclude: ['src/**/*'],
+      }),
+    )
+    rebuildRuntimeProgram(runtime, { fileName: configPath, event: 'update' })
+
+    expect(runtime.getHost()).not.toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(initialPath))).toBeUndefined()
+    expect(runtime.getProgram().getSourceFile(normalizePath(extraPath))).toBeDefined()
+    expect(
+      (runtime as any).aliases.some((alias: any) =>
+        typeof alias.find === 'string' ? alias.find === '#/' : alias.find.test('#/extra'),
+      ),
+    ).toBe(true)
+  })
+
+  it('should reuse an updated external declaration and watch it', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    mkdirSync(resolve(tempDir, 'src'))
+    mkdirSync(resolve(tempDir, 'external'))
+    const sourcePath = resolve(tempDir, 'src/index.ts')
+    const declarationPath = resolve(tempDir, 'external/types.d.ts')
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true }, include: ['src/**/*'] }),
+    )
+    writeFileSync(
+      sourcePath,
+      "import type { External } from '../external/types'\nexport type Value = External\n",
+    )
+    writeFileSync(declarationPath, 'export interface External { value: string }\n')
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    const initialProgram = runtime.getProgram()
+    const initialSource = initialProgram.getSourceFile(normalizePath(sourcePath))!
+    const initialDeclaration = initialProgram.getSourceFile(normalizePath(declarationPath))!
+    expect(getRuntimeWatchTargets(runtime).files).toContain(normalizePath(declarationPath))
+
+    writeFileSync(declarationPath, 'export interface External { value: number }\n')
+    rebuildRuntimeProgram(runtime, { fileName: declarationPath, event: 'update' })
+
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))).toBe(initialSource)
+    expect(runtime.getProgram().getSourceFile(normalizePath(declarationPath))).not.toBe(
+      initialDeclaration,
+    )
+  })
+
+  it('should use fresh fallback for JSON and custom resolver updates', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    mkdirSync(resolve(tempDir, 'src'))
+    const sourcePath = resolve(tempDir, 'src/index.ts')
+    const jsonPath = resolve(tempDir, 'src/data.json')
+    const customPath = resolve(tempDir, 'src/schema.grammar')
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: { moduleResolution: 'bundler', resolveJsonModule: true },
+        include: ['src/**/*'],
+      }),
+    )
+    writeFileSync(sourcePath, "import data from './data.json'\nexport { data }\n")
+    writeFileSync(jsonPath, '{"value":"before"}\n')
+    writeFileSync(customPath, 'before\n')
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      resolvers: [
+        {
+          name: 'grammar',
+          supports: id => id.endsWith('.grammar'),
+          transform: () => [],
+        },
+      ],
+    })
+    const createFreshRuntime = () =>
+      Runtime.toInstance({
+        processor: 'ts',
+        root: tempDir,
+        tsconfigPath: 'tsconfig.json',
+        resolvers: [
+          {
+            name: 'grammar',
+            supports: id => id.endsWith('.grammar'),
+            transform: () => [],
+          },
+        ],
+      })
+    let previousHost = runtime.getHost()
+    let previousSource = runtime.getProgram().getSourceFile(normalizePath(sourcePath))!
+
+    writeFileSync(jsonPath, '{"value":"after"}\n')
+    rebuildRuntimeProgram(runtime, { fileName: jsonPath, event: 'update' })
+    expect(runtime.getHost()).not.toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))).not.toBe(previousSource)
+    expect(runtime.getProgram().getSourceFile(normalizePath(jsonPath))?.text).toContain('after')
+    expect(emitDeclarations(runtime.getProgram())).toEqual(
+      emitDeclarations((await createFreshRuntime()).getProgram()),
+    )
+
+    previousHost = runtime.getHost()
+    previousSource = runtime.getProgram().getSourceFile(normalizePath(sourcePath))!
+    writeFileSync(customPath, 'after\n')
+    rebuildRuntimeProgram(runtime, { fileName: customPath, event: 'update' })
+    expect(runtime.getHost()).not.toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))).not.toBe(previousSource)
+    expect(emitDeclarations(runtime.getProgram())).toEqual(
+      emitDeclarations((await createFreshRuntime()).getProgram()),
+    )
+  })
+
+  it('should fall back to a fresh Program when the internal cache switch is disabled', async () => {
+    vi.stubEnv('DTS_DISABLE_SOURCE_FILE_CACHE', '1')
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+    const sourcePath = resolve(tempDir, 'index.ts')
+    const unchangedPath = resolve(tempDir, 'unchanged.ts')
+    writeFileSync(resolve(tempDir, 'tsconfig.json'), JSON.stringify({ include: ['*.ts'] }))
+    writeFileSync(sourcePath, "export const value = 'before'\n")
+    writeFileSync(unchangedPath, 'export const unchanged = true\n')
+
+    const runtime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    const previousHost = runtime.getHost()
+    const previousSourceFile = runtime.getProgram().getSourceFile(normalizePath(sourcePath))!
+    const previousUnchangedSourceFile = runtime
+      .getProgram()
+      .getSourceFile(normalizePath(unchangedPath))!
+    const previousDeclarations = emitDeclarations(runtime.getProgram())
+
+    writeFileSync(sourcePath, "export const value = 'after'\n")
+    rebuildRuntimeProgram(runtime, { fileName: sourcePath, event: 'update' })
+
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))).not.toBe(
+      previousSourceFile,
+    )
+    expect(runtime.getHost()).toBe(previousHost)
+    expect(runtime.getProgram().getSourceFile(normalizePath(unchangedPath))).not.toBe(
+      previousUnchangedSourceFile,
+    )
+    const freshRuntime = await Runtime.toInstance({
+      processor: 'ts',
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+    })
+    const rebuiltDeclarations = emitDeclarations(runtime.getProgram())
+    expect(rebuiltDeclarations).toEqual(emitDeclarations(freshRuntime.getProgram()))
+    expect(rebuiltDeclarations).not.toEqual(previousDeclarations)
   })
 
   it('should use baseUrl when explicitly set', async () => {

--- a/packages/unplugin-dts/tests/watch.spec.ts
+++ b/packages/unplugin-dts/tests/watch.spec.ts
@@ -1,0 +1,704 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { rspack } from '@rspack/core'
+import { watch as rollupWatch } from 'rollup'
+import { build } from 'vite'
+import webpack from 'webpack'
+
+import { normalizePath } from '../src/core/utils'
+import { mergeNativeWatchIgnored } from '../src/plugin'
+import rollupDts from '../src/rollup'
+import rspackDts from '../src/rspack'
+import viteDts from '../src/vite'
+import webpackDts from '../src/webpack'
+
+import type { RollupWatcher, RollupWatcherEvent } from 'rollup'
+import type { Runtime } from '../src/core/runtime'
+
+interface Watching {
+  close(callback: () => void): void,
+}
+
+interface WatchCompiler {
+  hooks: {
+    afterDone: {
+      tap(name: string, callback: () => void): void,
+    },
+    invalid: {
+      tap(name: string, callback: (fileName?: string) => void): void,
+    },
+  },
+  modifiedFiles?: ReadonlySet<string>,
+  removedFiles?: ReadonlySet<string>,
+  watch(
+    options: { aggregateTimeout: number },
+    callback: (error?: Error | null, stats?: { hasErrors(): boolean, toString(): string }) => void
+  ): Watching,
+}
+
+describe('native watch ignored merging', () => {
+  const asPredicate = (ignored: ReturnType<typeof mergeNativeWatchIgnored>) =>
+    ignored as (fileName: string) => boolean
+
+  it('should preserve Watchpack string and string-array glob semantics', () => {
+    const stringIgnored = asPredicate(mergeNativeWatchIgnored('**/node_modules', () => false))
+    const arrayIgnored = asPredicate(mergeNativeWatchIgnored(['**/*.tmp', '**/cache'], () => false))
+
+    expect(stringIgnored('/project/node_modules/package/index.js')).toBe(true)
+    expect(stringIgnored('/project/src/index.ts')).toBe(false)
+    expect(arrayIgnored('/project/src/result.tmp')).toBe(true)
+    expect(arrayIgnored('/project/cache/item.json')).toBe(true)
+    expect(arrayIgnored('/project/src/item.json')).toBe(false)
+  })
+
+  it('should preserve function input and match additional paths literally', () => {
+    const received: string[] = []
+    const outputDirectory = '/project[alias]/bundle'
+    const merged = asPredicate(
+      mergeNativeWatchIgnored(
+        fileName => {
+          received.push(fileName)
+          return fileName.endsWith('.cache')
+        },
+        fileName => fileName === outputDirectory || fileName.startsWith(`${outputDirectory}/`),
+      ),
+    )
+
+    expect(merged('C:\\project\\source.cache')).toBe(true)
+    expect(received).toEqual(['C:\\project\\source.cache'])
+    expect(merged('/project[alias]/bundle/index.js')).toBe(true)
+    expect(merged('/projecta/bundle/index.js')).toBe(false)
+  })
+})
+
+function writeFixture(root: string, include: string, entry: string) {
+  writeFileSync(
+    resolve(root, 'tsconfig.json'),
+    JSON.stringify({ compilerOptions: { strict: true }, include: [include] }),
+  )
+  writeFileSync(resolve(root, entry), 'export const entry = true\n')
+}
+
+async function waitForViteBundle(watcher: RollupWatcher, timeoutMs: number) {
+  return await new Promise<void>((fulfill, reject) => {
+    const timer = setTimeout(
+      () => finish(new Error('Timed out waiting for Vite bundle')),
+      timeoutMs,
+    )
+    function finish(error?: Error) {
+      clearTimeout(timer)
+      watcher.off('event', onEvent)
+      error ? reject(error) : fulfill()
+    }
+    function onEvent(event: RollupWatcherEvent) {
+      if (event.code === 'BUNDLE_END') finish()
+      else if (event.code === 'ERROR') {
+        finish(new Error(event.error?.message ?? 'Vite watch failed'))
+      }
+    }
+    watcher.on('event', onEvent)
+  })
+}
+
+async function runContextWatch(
+  compiler: WatchCompiler,
+  root: string,
+  declarationPath: string,
+  maximumBuilds: number,
+) {
+  let builds = 0
+  let initialBuilds = 0
+  let phase: 'initial' | 'create' = 'initial'
+  let watching: Watching
+
+  await new Promise<void>((fulfill, reject) => {
+    let settled = false
+    let actionTimer: ReturnType<typeof setTimeout> | undefined
+    const timeout = setTimeout(
+      () => finish(new Error('Timed out waiting for context dependency rebuild')),
+      10_000,
+    )
+    function finish(error?: Error) {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      if (actionTimer) clearTimeout(actionTimer)
+      watching.close(() => (error ? reject(error) : fulfill()))
+    }
+
+    watching = compiler.watch({ aggregateTimeout: 50 }, (error, stats) => {
+      if (error || stats?.hasErrors()) {
+        finish(error ?? new Error(stats?.toString() || 'Compiler watch failed'))
+        return
+      }
+
+      builds++
+      if (phase === 'initial') {
+        initialBuilds++
+        if (initialBuilds >= maximumBuilds) {
+          finish(new Error('Context watcher exceeded its bootstrap build allowance'))
+          return
+        }
+        if (actionTimer) clearTimeout(actionTimer)
+        actionTimer = setTimeout(() => {
+          phase = 'create'
+          writeFileSync(resolve(root, 'src/new.ts'), 'export const created = true\n')
+        }, 3000)
+        return
+      }
+
+      if (builds !== initialBuilds + 1 || !existsSync(declarationPath)) {
+        finish(new Error('Context source creation did not produce exactly one valid rebuild'))
+        return
+      }
+      actionTimer = setTimeout(() => {
+        if (builds !== initialBuilds + 1) {
+          finish(new Error('Generated output triggered an unexpected context rebuild'))
+        } else {
+          finish()
+        }
+      }, 750)
+    })
+  })
+
+  expect(builds).toBe(initialBuilds + 1)
+  expect(builds).toBeLessThanOrEqual(maximumBuilds)
+  expect(existsSync(declarationPath)).toBe(true)
+}
+
+async function runUnsafeRootWatchLifecycle(
+  compiler: WatchCompiler,
+  root: string,
+  outputDirectory: string,
+  getRuntime: () => Runtime,
+) {
+  let builds = 0
+  let bootstrapBuilds = 0
+  let watching: Watching
+  const pendingInvalidations: string[] = []
+
+  await new Promise<void>((fulfill, reject) => {
+    let settled = false
+    let expectedBuild: 'initial' | 'probe' | 'create' | 'rename' | 'delete' | 'stable' = 'initial'
+    let pendingAction: (() => void) | undefined
+    let actionTimer: ReturnType<typeof setTimeout> | undefined
+    let quietTimer: ReturnType<typeof setTimeout> | undefined
+    const timeout = setTimeout(
+      () => finish(new Error(`Timed out waiting for ${expectedBuild} compiler build`)),
+      20_000,
+    )
+    function finish(error?: Error) {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      if (actionTimer) clearTimeout(actionTimer)
+      if (quietTimer) clearTimeout(quietTimer)
+      watching.close(() => (error ? reject(error) : fulfill()))
+    }
+
+    function afterWatchReady(action: () => void) {
+      pendingAction = action
+    }
+
+    compiler.hooks.invalid.tap('unplugin-dts-watch-test', fileName => {
+      if (fileName) pendingInvalidations.push(normalizePath(fileName))
+    })
+
+    compiler.hooks.afterDone.tap('unplugin-dts-watch-test', () => {
+      const action = pendingAction
+      if (!action || settled) return
+      if (actionTimer) clearTimeout(actionTimer)
+      actionTimer = setTimeout(() => {
+        if (pendingAction !== action) return
+        pendingAction = undefined
+        try {
+          action()
+        } catch (error) {
+          finish(error instanceof Error ? error : new Error(String(error)))
+        }
+      }, 500)
+    })
+
+    watching = compiler.watch({ aggregateTimeout: 50 }, (error, stats) => {
+      if (error || stats?.hasErrors()) {
+        finish(error ?? new Error(stats?.toString() || 'Compiler watch failed'))
+        return
+      }
+
+      builds++
+      try {
+        const invalidations = pendingInvalidations.splice(0)
+        const modifiedFiles = [...(compiler.modifiedFiles ?? [])].map(normalizePath)
+        const removedFiles = [...(compiler.removedFiles ?? [])].map(normalizePath)
+        const normalizedOutputDirectory = normalizePath(outputDirectory)
+        const isOutputPath = (fileName: string) =>
+          fileName === normalizedOutputDirectory ||
+          fileName.startsWith(`${normalizedOutputDirectory}/`)
+        expect([...invalidations, ...modifiedFiles, ...removedFiles].some(isOutputPath)).toBe(false)
+
+        if (pendingAction) {
+          if (expectedBuild === 'probe' && bootstrapBuilds === 0) {
+            bootstrapBuilds++
+            return
+          }
+          finish(
+            new Error(
+              `Unexpected ${expectedBuild} rebuild before its source action; invalidations=${JSON.stringify(invalidations)}`,
+            ),
+          )
+          return
+        }
+
+        if (expectedBuild === 'initial') {
+          expectedBuild = 'probe'
+          afterWatchReady(() => {
+            writeFileSync(resolve(root, 'index.ts'), 'export const entry = false\n')
+          })
+          return
+        }
+
+        if (expectedBuild === 'probe') {
+          const probeSource = getRuntime()
+            .getProgram()
+            .getSourceFile(normalizePath(resolve(root, 'index.ts')))
+          if (!probeSource?.text.includes('false') && bootstrapBuilds === 0) {
+            bootstrapBuilds++
+            return
+          }
+          expect(probeSource?.text).toContain('false')
+          expectedBuild = 'create'
+          afterWatchReady(() => {
+            writeFileSync(resolve(root, 'new.ts'), 'export const created = true\n')
+          })
+          return
+        }
+
+        if (expectedBuild === 'create') {
+          const createdDeclaration = existsSync(resolve(outputDirectory, 'new.d.ts'))
+          const createdSource = getRuntime()
+            .getProgram()
+            .getSourceFile(normalizePath(resolve(root, 'new.ts')))
+          expect(modifiedFiles).toContain(normalizePath(root))
+          expect(createdDeclaration).toBe(true)
+          expect(createdSource).toBeTruthy()
+          expectedBuild = 'rename'
+          afterWatchReady(() => {
+            renameSync(resolve(root, 'new.ts'), resolve(root, 'renamed.ts'))
+          })
+          return
+        }
+
+        if (expectedBuild === 'rename') {
+          const previousSource = getRuntime()
+            .getProgram()
+            .getSourceFile(normalizePath(resolve(root, 'new.ts')))
+          const renamedSource = getRuntime()
+            .getProgram()
+            .getSourceFile(normalizePath(resolve(root, 'renamed.ts')))
+          const renamedDeclaration = existsSync(resolve(outputDirectory, 'renamed.d.ts'))
+          expect(previousSource).toBeFalsy()
+          expect(renamedSource).toBeTruthy()
+          expect(renamedDeclaration).toBe(true)
+          expectedBuild = 'delete'
+          afterWatchReady(() => {
+            rmSync(resolve(root, 'renamed.ts'))
+          })
+          return
+        }
+
+        if (expectedBuild === 'stable') {
+          finish(new Error('Generated output triggered an unexpected compiler rebuild'))
+          return
+        }
+
+        const deletedSource = getRuntime()
+          .getProgram()
+          .getSourceFile(normalizePath(resolve(root, 'renamed.ts')))
+        expect(deletedSource).toBeFalsy()
+        expectedBuild = 'stable'
+        afterWatchReady(() => {
+          watching.close(() => {
+            const closedBuilds = builds
+            writeFileSync(resolve(root, 'after-close.ts'), 'export const closed = true\n')
+            quietTimer = setTimeout(() => {
+              if (builds !== closedBuilds) {
+                finish(new Error('Closed compiler watcher rebuilt after a source change'))
+              } else {
+                settled = true
+                clearTimeout(timeout)
+                fulfill()
+              }
+            }, 500)
+          })
+        })
+      } catch (callbackError) {
+        finish(callbackError instanceof Error ? callbackError : new Error(String(callbackError)))
+      }
+    })
+  })
+
+  expect(bootstrapBuilds).toBeLessThanOrEqual(1)
+  expect(builds).toBe(5 + bootstrapBuilds)
+}
+
+async function runSymlinkOutputWatch(
+  compiler: WatchCompiler,
+  root: string,
+  sourcePath: string,
+  getRuntime: () => Runtime,
+) {
+  let builds = 0
+  let initialBuilds = 0
+  let phase: 'initial' | 'structural' | 'update' = 'initial'
+  let watching: Watching
+
+  await new Promise<void>((fulfill, reject) => {
+    let settled = false
+    let actionTimer: ReturnType<typeof setTimeout> | undefined
+    const timeout = setTimeout(
+      () => finish(new Error('Timed out waiting for symlink output watcher')),
+      15_000,
+    )
+    function finish(error?: Error) {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      if (actionTimer) clearTimeout(actionTimer)
+      watching.close(() => (error ? reject(error) : fulfill()))
+    }
+
+    watching = compiler.watch({ aggregateTimeout: 50 }, (error, stats) => {
+      if (error || stats?.hasErrors()) {
+        finish(error ?? new Error(stats?.toString() || 'Compiler watch failed'))
+        return
+      }
+
+      builds++
+      if (phase === 'initial') {
+        initialBuilds++
+        if (initialBuilds > 2) {
+          finish(new Error('Symlinked output triggered more than one bootstrap rebuild'))
+          return
+        }
+        if (actionTimer) clearTimeout(actionTimer)
+        actionTimer = setTimeout(() => {
+          phase = 'structural'
+          writeFileSync(resolve(root, 'src/new.ts'), 'export const created = true\n')
+          actionTimer = setTimeout(() => {
+            if (builds !== initialBuilds) {
+              finish(new Error('Symlinked output kept a source context dependency active'))
+              return
+            }
+            phase = 'update'
+            writeFileSync(sourcePath, 'export const entry = false\n')
+          }, 750)
+        }, 3000)
+        return
+      }
+
+      if (phase === 'structural') {
+        finish(new Error('Symlinked output kept a source context dependency active'))
+        return
+      }
+
+      if (phase === 'update' && builds === initialBuilds + 1) {
+        try {
+          expect(
+            getRuntime().getProgram().getSourceFile(normalizePath(sourcePath))?.text,
+          ).toContain('false')
+          actionTimer = setTimeout(() => {
+            if (builds !== initialBuilds + 1) {
+              finish(new Error('Generated symlink output triggered a compiler rebuild'))
+              return
+            }
+            finish()
+          }, 750)
+        } catch (callbackError) {
+          finish(callbackError instanceof Error ? callbackError : new Error(String(callbackError)))
+        }
+        return
+      }
+
+      finish(new Error(`Unexpected compiler rebuild #${builds} for symlinked output`))
+    })
+  })
+
+  expect(initialBuilds).toBeLessThanOrEqual(2)
+  expect(builds).toBe(initialBuilds + 1)
+  expect(existsSync(resolve(root, 'src/new.d.ts'))).toBe(false)
+}
+
+describe('real watcher regressions', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('should rebuild Vite for a new root-level file with the default outDir', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-vite-watch-'))
+    writeFixture(tempDir, '*.ts', 'index.ts')
+    const plugin = viteDts({
+      root: tempDir,
+      processor: 'ts',
+      declarationOnly: true,
+    })
+    const watcher = (await build({
+      configFile: false,
+      root: tempDir,
+      logLevel: 'silent',
+      plugins: [plugin],
+      build: {
+        lib: { entry: resolve(tempDir, 'index.ts'), formats: ['es'], fileName: 'index' },
+        outDir: resolve(tempDir, 'dist'),
+        emptyOutDir: true,
+        watch: { clearScreen: false },
+      },
+    })) as RollupWatcher
+
+    let bundles = 0
+    watcher.on('event', event => {
+      if (event.code === 'BUNDLE_END') bundles++
+    })
+    try {
+      await waitForViteBundle(watcher, 10_000)
+      await new Promise(fulfill => setTimeout(fulfill, 750))
+      expect(bundles).toBe(1)
+      writeFileSync(resolve(tempDir, 'new.ts'), 'export const created = true\n')
+      await waitForViteBundle(watcher, 5_000)
+      await new Promise(fulfill => setTimeout(fulfill, 500))
+    } finally {
+      await watcher.close()
+    }
+
+    expect(bundles).toBe(2)
+    expect(existsSync(resolve(tempDir, 'dist/new.d.ts'))).toBe(true)
+  })
+
+  it('should ignore safe Vite bundler and declaration output aliases', async () => {
+    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-vite-alias-watch-'))
+    const realOutputDirectory = resolve(tempDir, 'real-output')
+    const outputLink = resolve(tempDir, 'bundle')
+    const declarationDirectory = resolve(outputLink, 'types')
+    mkdirSync(realOutputDirectory)
+    symlinkSync(realOutputDirectory, outputLink, process.platform === 'win32' ? 'junction' : 'dir')
+    writeFixture(tempDir, '*.ts', 'index.ts')
+    const watcher = (await build({
+      configFile: false,
+      root: tempDir,
+      logLevel: 'silent',
+      plugins: [
+        viteDts({
+          root: tempDir,
+          processor: 'ts',
+          outDirs: declarationDirectory,
+        }),
+      ],
+      build: {
+        lib: { entry: resolve(tempDir, 'index.ts'), formats: ['es'], fileName: 'index' },
+        outDir: resolve(outputLink, 'bundle'),
+        emptyOutDir: true,
+        watch: { clearScreen: false },
+      },
+    })) as RollupWatcher
+    let bundles = 0
+    watcher.on('event', event => {
+      if (event.code === 'BUNDLE_END') bundles++
+    })
+
+    try {
+      await waitForViteBundle(watcher, 10_000)
+      await new Promise(fulfill => setTimeout(fulfill, 1500))
+      expect(bundles).toBe(1)
+      writeFileSync(resolve(tempDir, 'new.ts'), 'export const created = true\n')
+      await waitForViteBundle(watcher, 5_000)
+      await new Promise(fulfill => setTimeout(fulfill, 750))
+    } finally {
+      await watcher.close()
+    }
+
+    expect(bundles).toBe(2)
+    expect(existsSync(resolve(realOutputDirectory, 'bundle/index.mjs'))).toBe(true)
+    expect(existsSync(resolve(realOutputDirectory, 'types/new.d.ts'))).toBe(true)
+  })
+
+  it('should keep exact Vite source watches when declaration outDir contains the source', async () => {
+    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-vite-overlap-'))
+    writeFixture(tempDir, '*.ts', 'index.ts')
+    const sourcePath = resolve(tempDir, 'index.ts')
+    let runtime: any
+    const watcher = (await build({
+      configFile: false,
+      root: tempDir,
+      logLevel: 'silent',
+      plugins: [
+        viteDts({
+          root: tempDir,
+          processor: 'ts',
+          declarationOnly: true,
+          outDirs: tempDir,
+          afterBootstrap(instance) {
+            runtime = instance
+          },
+        }),
+      ],
+      build: {
+        lib: { entry: sourcePath, formats: ['es'], fileName: 'index' },
+        outDir: resolve(tempDir, 'dist'),
+        emptyOutDir: true,
+        watch: { clearScreen: false },
+      },
+    })) as RollupWatcher
+    let bundles = 0
+    watcher.on('event', event => {
+      if (event.code === 'BUNDLE_END') bundles++
+    })
+
+    try {
+      await waitForViteBundle(watcher, 10_000)
+      await new Promise(fulfill => setTimeout(fulfill, 500))
+      writeFileSync(sourcePath, 'export const entry = false\n')
+      await waitForViteBundle(watcher, 5_000)
+    } finally {
+      await watcher.close()
+    }
+
+    expect(bundles).toBe(2)
+    expect(runtime.getProgram().getSourceFile(normalizePath(sourcePath))?.text).toContain('false')
+  })
+
+  it('should fail closed when a Rollup output alias is nested in a source directory', async () => {
+    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-rollup-alias-watch-'))
+    const sourceDirectory = resolve(tempDir, 'src')
+    const realOutputDirectory = resolve(sourceDirectory, 'generated')
+    const outputLink = resolve(tempDir, 'bundle')
+    const declarationDirectory = resolve(tempDir, 'types')
+    mkdirSync(realOutputDirectory, { recursive: true })
+    symlinkSync(realOutputDirectory, outputLink, process.platform === 'win32' ? 'junction' : 'dir')
+    writeFixture(tempDir, 'src/*.ts', 'src/index.ts')
+    const watcher = rollupWatch({
+      input: resolve(sourceDirectory, 'index.ts'),
+      output: { dir: outputLink, format: 'es' },
+      plugins: [rollupDts({ root: tempDir, processor: 'ts', outDirs: declarationDirectory })],
+    })
+    let bundles = 0
+    watcher.on('event', event => {
+      if (event.code === 'BUNDLE_END') bundles++
+    })
+
+    try {
+      await waitForViteBundle(watcher, 10_000)
+      await new Promise(fulfill => setTimeout(fulfill, 1500))
+      expect(bundles).toBe(1)
+      writeFileSync(resolve(sourceDirectory, 'new.ts'), 'export const created = true\n')
+      await new Promise(fulfill => setTimeout(fulfill, 1000))
+    } finally {
+      await watcher.close()
+    }
+
+    expect(bundles).toBe(1)
+    expect(existsSync(resolve(declarationDirectory, 'new.d.ts'))).toBe(false)
+  })
+
+  it('should resolve the nearest existing output symlink ancestor for Webpack watch', async () => {
+    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-symlink-parent-watch-'))
+    const projectRoot = resolve(tempDir, 'project')
+    const sourceDirectory = resolve(projectRoot, 'src')
+    const outputLink = resolve(projectRoot, 'bundle')
+    const outputDirectory = resolve(outputLink, 'generated')
+    mkdirSync(sourceDirectory, { recursive: true })
+    writeFixture(projectRoot, 'src/*.ts', 'src/index.ts')
+    symlinkSync(sourceDirectory, outputLink, process.platform === 'win32' ? 'junction' : 'dir')
+    const config = {
+      mode: 'production' as const,
+      context: projectRoot,
+      entry: './src/index.ts',
+      output: { path: outputDirectory, filename: 'index.js' },
+      resolve: { extensions: ['.ts', '.js'] },
+      plugins: [webpackDts({ root: projectRoot, processor: 'ts' })],
+    }
+    const compiler = webpack(config) as unknown as WatchCompiler
+
+    await runContextWatch(compiler, projectRoot, resolve(sourceDirectory, 'generated/new.d.ts'), 3)
+  }, 15_000)
+
+  it.each([
+    ['Webpack', webpackDts, (config: webpack.Configuration) => webpack(config)],
+    ['Rspack', rspackDts, (config: Parameters<typeof rspack>[0]) => rspack(config)],
+  ] as const)(
+    'should safely watch a root-level %s source context with bounded bootstrap rebuilds',
+    async (_, createDts, createCompiler) => {
+      tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-output-watch-'))
+      const projectRoot = resolve(tempDir, 'project')
+      mkdirSync(projectRoot)
+      writeFixture(projectRoot, '*.ts', 'index.ts')
+      const outputDirectory = resolve(projectRoot, 'bundle')
+      mkdirSync(outputDirectory)
+      let runtime!: Runtime
+      const config = {
+        mode: 'production' as const,
+        context: projectRoot,
+        entry: './index.ts',
+        output: { path: outputDirectory, filename: 'index.js' },
+        resolve: { extensions: ['.ts', '.js'] },
+        plugins: [
+          createDts({
+            root: projectRoot,
+            processor: 'ts',
+            afterBootstrap(instance) {
+              runtime = instance
+            },
+          }),
+        ],
+      }
+      const compiler = createCompiler(config as never) as unknown as WatchCompiler
+
+      await runUnsafeRootWatchLifecycle(compiler, projectRoot, outputDirectory, () => runtime)
+    },
+    30_000,
+  )
+
+  it('should fail closed when the Rspack output symlink resolves into the source tree', async () => {
+    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-symlink-watch-'))
+    const projectRoot = resolve(tempDir, 'project')
+    const sourceDirectory = resolve(projectRoot, 'src')
+    const outputDirectory = resolve(projectRoot, 'bundle')
+    mkdirSync(sourceDirectory, { recursive: true })
+    writeFixture(projectRoot, 'src/*.ts', 'src/index.ts')
+    symlinkSync(sourceDirectory, outputDirectory, process.platform === 'win32' ? 'junction' : 'dir')
+    const sourcePath = resolve(sourceDirectory, 'index.ts')
+    let runtime!: Runtime
+    const config = {
+      mode: 'production' as const,
+      context: projectRoot,
+      entry: './src/index.ts',
+      output: { path: outputDirectory, filename: 'index.js' },
+      resolve: { extensions: ['.ts', '.js'] },
+      plugins: [
+        rspackDts({
+          root: projectRoot,
+          processor: 'ts',
+          afterBootstrap(instance) {
+            runtime = instance
+          },
+        }),
+      ],
+    }
+    const compiler = rspack(config) as unknown as WatchCompiler
+
+    await runSymlinkOutputWatch(compiler, projectRoot, sourcePath, () => runtime)
+  }, 20_000)
+})

--- a/packages/unplugin-dts/tests/watch.spec.ts
+++ b/packages/unplugin-dts/tests/watch.spec.ts
@@ -92,6 +92,10 @@ function writeFixture(root: string, include: string, entry: string) {
   writeFileSync(resolve(root, entry), 'export const entry = true\n')
 }
 
+function createTempDirectory(prefix: string) {
+  return mkdtempSync(resolve(realpathSync.native(tmpdir()), prefix))
+}
+
 async function waitForViteBundle(watcher: RollupWatcher, timeoutMs: number) {
   return await new Promise<void>((fulfill, reject) => {
     const timer = setTimeout(
@@ -449,7 +453,7 @@ describe('real watcher regressions', () => {
   })
 
   it('should rebuild Vite for a new root-level file with the default outDir', async () => {
-    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-vite-watch-'))
+    tempDir = createTempDirectory('unplugin-dts-vite-watch-')
     writeFixture(tempDir, '*.ts', 'index.ts')
     const plugin = viteDts({
       root: tempDir,
@@ -489,7 +493,7 @@ describe('real watcher regressions', () => {
   })
 
   it('should ignore safe Vite bundler and declaration output aliases', async () => {
-    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-vite-alias-watch-'))
+    tempDir = createTempDirectory('unplugin-dts-vite-alias-watch-')
     const realOutputDirectory = resolve(tempDir, 'real-output')
     const outputLink = resolve(tempDir, 'bundle')
     const declarationDirectory = resolve(outputLink, 'types')
@@ -536,7 +540,7 @@ describe('real watcher regressions', () => {
   })
 
   it('should keep exact Vite source watches when declaration outDir contains the source', async () => {
-    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-vite-overlap-'))
+    tempDir = createTempDirectory('unplugin-dts-vite-overlap-')
     writeFixture(tempDir, '*.ts', 'index.ts')
     const sourcePath = resolve(tempDir, 'index.ts')
     let runtime: any
@@ -581,7 +585,7 @@ describe('real watcher regressions', () => {
   })
 
   it('should fail closed when a Rollup output alias is nested in a source directory', async () => {
-    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-rollup-alias-watch-'))
+    tempDir = createTempDirectory('unplugin-dts-rollup-alias-watch-')
     const sourceDirectory = resolve(tempDir, 'src')
     const realOutputDirectory = resolve(sourceDirectory, 'generated')
     const outputLink = resolve(tempDir, 'bundle')
@@ -614,7 +618,7 @@ describe('real watcher regressions', () => {
   })
 
   it('should resolve the nearest existing output symlink ancestor for Webpack watch', async () => {
-    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-symlink-parent-watch-'))
+    tempDir = createTempDirectory('unplugin-dts-symlink-parent-watch-')
     const projectRoot = resolve(tempDir, 'project')
     const sourceDirectory = resolve(projectRoot, 'src')
     const outputLink = resolve(projectRoot, 'bundle')
@@ -641,7 +645,7 @@ describe('real watcher regressions', () => {
   ] as const)(
     'should safely watch a root-level %s source context with bounded bootstrap rebuilds',
     async (_, createDts, createCompiler) => {
-      tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-output-watch-'))
+      tempDir = createTempDirectory('unplugin-dts-output-watch-')
       const projectRoot = resolve(tempDir, 'project')
       mkdirSync(projectRoot)
       writeFixture(projectRoot, '*.ts', 'index.ts')
@@ -672,7 +676,7 @@ describe('real watcher regressions', () => {
   )
 
   it('should fail closed when the Rspack output symlink resolves into the source tree', async () => {
-    tempDir = mkdtempSync(resolve(realpathSync(tmpdir()), 'unplugin-dts-symlink-watch-'))
+    tempDir = createTempDirectory('unplugin-dts-symlink-watch-')
     const projectRoot = resolve(tempDir, 'project')
     const sourceDirectory = resolve(projectRoot, 'src')
     const outputDirectory = resolve(projectRoot, 'bundle')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       esbuild:
         specifier: '*'
         version: 0.25.8
+      glob-to-regexp:
+        specifier: 0.4.1
+        version: 0.4.1
       kolorist:
         specifier: ^1.8.0
         version: 1.8.0


### PR DESCRIPTION
## 概述

优化 TypeScript 项目在 watch 模式下的 Program 重建和文件监听生命周期，同时补齐跨 bundler 的新增、删除、重命名与输出目录隔离行为。

该 PR 只包含 TypeScript watch 与通用 watcher 基础设施，不包含后续 Vue/Volar 生命周期调整，也不改变公开 API 或选项。

## 主要变更

- 为纯 TypeScript processor 增加按版本失效的 SourceFile cache，并把旧 Program 交给 TypeScript 复用未变化 AST。
- 将同一构建轮次的多个 watchChange 聚合到下一次 buildStart，只重建一次 Program、执行一次完整 diagnostics。
- 对创建、删除、重命名、tsconfig、JSON 和自定义 resolver 等不安全场景使用 fresh fallback。
- 修正 Vite、Webpack、Rspack、Rollup 和 Rolldown 的文件/目录监听、输出目录忽略和 stale declaration 清理边界。
- 增加可区分 hook 归因、transform 并行重叠与未归因墙钟的性能计时。
- 补充 watch 模式的布局建议与已知 bundler 边界文档。

## 性能结果

冻结的 7 组配对 A/B benchmark 中：

- 普通单文件或公共依赖增量构建耗时降低约 19%–27%。
- 同一轮多文件修改耗时降低约 35%–46%。
- 120/480 文件 cold build 中位数约慢 1.5%，因此该 PR 不宣称冷构建收益。

480 文件公共依赖场景中，watchChange 的下降部分确实转移到了 buildStart；但 transform 从 38.9ms 降至 0.6ms，writeBundle 从 306.5ms 降至 203.4ms，关键路径归因合计从 511.7ms 降至 359.6ms。SourceFile identity 观测显示 566/567 个 SourceFile 被复用。

## 正确性与验证

- fresh oracle 14/14 场景通过，预期一致的产物文件集合和逐文件 SHA-256 均与独立 fresh build 相同。
- `pnpm --filter unplugin-dts test`：PR1 独立状态 11 files / 78 tests passed。
- TypeScript 类型检查、目标 ESLint、`git diff --check` 通过。
- `pnpm build` 通过。
- `playground/ts-vite` 和原有 `playground/vue-vite` 构建通过。
- 真实 Vite、Webpack、Rspack watcher 回归测试通过。

## 已知边界

纯 Rollup/Rolldown 在递归源码目录与输出目录重叠时继续 fail-close，避免生成文件形成无限 rebuild；这种布局下，未被引用的新文件可能需要调整目录布局或重启 watcher。